### PR TITLE
SDK v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 vendor
+*.swp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ The json file may look like this:
   # => Environment credentials
   # These are your environment credentials, you can get them by connecting on the developer platform, then go on your app, they will be display under the technical view on each environment.
   "environment": {
-    "name": "<your environment nid>"
     "api_key": "<your environment key>",
     "api_secret": "<your environment secret>"
   }
@@ -104,7 +103,6 @@ You can also use environment variables to configure your app environment:
 ```
 export MNO_DEVPL_HOST=<developer platform host>
 export MNO_DEVPL_API_PATH=<developer platform host>
-export MNO_DEVPL_ENV_NAME=<your environment nid>
 export MNO_DEVPL_ENV_KEY=<your environment key>
 export MNO_DEVPL_ENV_SECRET=<your environment secret>
 ```

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ if ($resp->isValid()) {
     $_SESSION["id"] = $user->getId();
     $_SESSION["email"] = $user->getEmail();
 
+    $_SESSION["vid"] = $user->getVirtualId();
+    $_SESSION["vemail"] = $user->getVirtualEmail();
+
     // Store group details
     $_SESSION["groupId"] = $group->getId();
     $_SESSION["groupName"] = $group->getName();

--- a/README.md
+++ b/README.md
@@ -166,13 +166,11 @@ if ($resp->isValid()) {
     $_SESSION["lastName"] = $user->getLastName();
     $_SESSION["marketplace"] = $_GET['marketplace'];
 
-    // TODO: Update this comment
-    // Important - toId() and toEmail() have different behaviour compared to
-    // getId() and getEmail(). In you maestrano configuration file, if your sso > creation_mode 
-    // is set to 'real' then toId() and toEmail() return the actual id and email of the user which
-    // are only unique across users.
-    // If you chose 'virtual' then toId() and toEmail() will return a virtual (or composite) attribute
-    // which is truly unique across users and groups
+    // Important - Real id/email and Virtual id/email (recommended)
+    // getId() and getEmail() return the actual id and email of the user which are only unique across users.
+    // If you chose to use the 'virtual mode' then use getVirtualId() and getVirtualEmail().
+    // They return a virtual (or composite) attribute which is truly unique across users and groups
+    // Do not use the virtual email address to send emails to the user
     $_SESSION["id"] = $user->getId();
     $_SESSION["email"] = $user->getEmail();
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ if ($resp->isValid()) {
 
     // Once the user is created/identified, we store the maestrano
     // session. This session will be used for single logout
-    $mnoSession = Maestrano_Sso_Session::create($_SESSION["marketplace"], $_SESSION, $user);
+    $mnoSession = new Maestrano_Sso_Session($_SESSION["marketplace"], $_SESSION, $user);
     $mnoSession->save();
 
     // Redirect the user to home page
@@ -198,7 +198,7 @@ Note that for the consume action you should disable CSRF authenticity if your fr
 If you want your users to benefit from single logout then you should define the following filter in a module and include it in all your controllers except the one handling single sign-on authentication.
 
 ```php
-$mnoSession = Maestrano_Sso_Session::create($_SESSION["marketplace"], $_SESSION);
+$mnoSession = new Maestrano_Sso_Session($_SESSION["marketplace"], $_SESSION);
 
 // Trigger SSO handshake if session not valid anymore
 if (!$mnoSession->isValid()) {
@@ -222,7 +222,7 @@ session_start();
 session_destroy();
 
 // Redirect to IDP logout url
-$mnoSession = Maestrano_Sso_Session::create($_SESSION["marketplace"], $_SESSION);
+$mnoSession = new Maestrano_Sso_Session($_SESSION["marketplace"], $_SESSION);
 $logoutUrl = $mnoSession->getLogoutUrl();
 
 header("Location: $logoutUrl");

--- a/README.md
+++ b/README.md
@@ -219,16 +219,6 @@ When Maestrano users sign out of your application you can redirect them to the M
 Maestrano::with($_SESSION['marketplace'])->sso()->getLogoutUrl()
 ```
 
-### Redirecting on error
-If any error happens during the SSO handshake, you can redirect users to the following URL:
-
-```php
-Maestrano::sso()->getUnauthorizedUrl()
-
-// With a configuration preset
-// Maestrano::with('my-config-preset')->sso()->getUnauthorizedUrl()
-```
-
 ## Account Webhooks
 Single sign on has been setup into your app and Maestrano users are now able to use your service. Great! Wait what happens when a business (group) decides to stop using your service? Also what happens when a user gets removed from a business? Well the controllers describes in this section are for Maestrano to be able to notify you of such events.
 

--- a/lib/Account/Bill.php
+++ b/lib/Account/Bill.php
@@ -3,156 +3,175 @@
 class Maestrano_Account_Bill extends Maestrano_Api_Resource
 {
 
-  /**
-   * @param string $class
-   *
-   * @returns string The endpoint URL for the Bill class
-   */
-  public static function classUrl($class)
-  {
-    return "/api/v1/account/bills";
-  }
+    /**
+     * @param string $class
+     *
+     * @returns string The endpoint URL for the Bill class
+     */
+    public static function classUrl($class)
+    {
+        return "/api/v1/account/bills";
+    }
 
-  /**
-   * @param string|null $preset
-   * @param string $id The ID of the bill to instantiate.
-   *
-   * @return Maestrano_Billing_Bill
-   */
-  public static function newWithPreset($preset,$id=null)
-  {
-    return new Maestrano_Account_Bill($id,$preset);
-  }
+    /**
+     * @param string|null $preset
+     * @param string $id The ID of the bill to instantiate.
+     *
+     * @return Maestrano_Account_Bill
+     */
+    public static function newWithPreset($preset, $id = null)
+    {
+        return new Maestrano_Account_Bill($id, $preset);
+    }
 
-  /**
-   * @param string|null $preset
-   * @param string $id The ID of the bill to retrieve.
-   *
-   * @return Maestrano_Billing_Bill
-   */
-  public static function retrieveWithPreset($preset,$id)
-  {
-    $class = get_class();
-    return self::_scopedRetrieve($class, $id, $preset);
-  }
+    /**
+     * @param string|null $preset
+     * @param string $id The ID of the bill to retrieve.
+     *
+     * @return Maestrano_Billing_Bill
+     */
+    public static function retrieveWithPreset($preset, $id)
+    {
+        $class = get_class();
+        return self::_scopedRetrieve($class, $id, $preset);
+    }
 
-  /**
-   * @param string|null $preset
-   * @param array|null $params
-   *
-   * @return array An array of Maestrano_Billing_Bills.
-   */
-  public static function allWithPreset($preset,$params=null)
-  {
-    $class = get_class();
-    return self::_scopedAll($class, $params, $preset);
-  }
+    /**
+     * @param string|null $preset
+     * @param array|null $params
+     *
+     * @return array An array of Maestrano_Billing_Bills.
+     */
+    public static function allWithPreset($preset, $params = null)
+    {
+        $class = get_class();
+        return self::_scopedAll($class, $params, $preset);
+    }
 
-  /**
-   * @param string|null $preset
-   * @param array|null $params
-   *
-   * @return Maestrano_Billing_Bill The created bill.
-   */
-  public static function createWithPreset($preset,$params=null)
-  {
-    $class = get_class();
-    return self::_scopedCreate($class, $params, $preset);
-  }
+    /**
+     * @param string|null $preset
+     * @param array|null $params
+     *
+     * @return Maestrano_Billing_Bill The created bill.
+     */
+    public static function createWithPreset($preset, $params = null)
+    {
+        $class = get_class();
+        return self::_scopedCreate($class, $params, $preset);
+    }
 
-  /**
-   * @return Maestrano_Billing_Bill The saved bill.
-   */
-  public function save()
-  {
-    $class = get_class();
-    return self::_scopedSave($class);
-  }
+    /**
+     * @return Maestrano_Billing_Bill The saved bill.
+     */
+    public function save()
+    {
+        $class = get_class();
+        return self::_scopedSave($class);
+    }
 
-  /**
-   * @return Maestrano_Billing_Bill The cancelled bill.
-   */
-  public function cancel($params=null)
-  {
-    $class = get_class();
-    self::_scopedDelete($class, $params);
-    return $this->getStatus() == 'cancelled';
-  }
+    /**
+     * @return Maestrano_Billing_Bill The cancelled bill.
+     */
+    public function cancel($params = null)
+    {
+        $class = get_class();
+        self::_scopedDelete($class, $params);
+        return $this->getStatus() == 'cancelled';
+    }
 
 
-	public function getId() {
-		return $this->id;
-	}
+    public function getId()
+    {
+        return $this->id;
+    }
 
-	public function setId($id) {
-		$this->id = $id;
-	}
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
 
-	public function getCreatedAt() {
-		return $this->created_at;
-	}
+    public function getCreatedAt()
+    {
+        return $this->created_at;
+    }
 
-	public function getUpdatedAt() {
-		return $this->updated_at;
-	}
+    public function getUpdatedAt()
+    {
+        return $this->updated_at;
+    }
 
-	public function getStatus() {
-		return $this->status;
-	}
+    public function getStatus()
+    {
+        return $this->status;
+    }
 
-	public function getUnits() {
-		return $this->units;
-	}
+    public function getUnits()
+    {
+        return $this->units;
+    }
 
-	public function setUnits($units) {
-    $this->units = $units;
-	}
+    public function setUnits($units)
+    {
+        $this->units = $units;
+    }
 
-	public function getPeriodStartedAt() {
-		return $this->period_started_at;
-	}
+    public function getPeriodStartedAt()
+    {
+        return $this->period_started_at;
+    }
 
-	public function setPeriodStartedAt($periodStartedAt) {
-    $this->period_started_at = $periodStartedAt;
-	}
+    public function setPeriodStartedAt($periodStartedAt)
+    {
+        $this->period_started_at = $periodStartedAt;
+    }
 
-	public function getPeriodEndedAt() {
-		return $this->period_ended_at;
-	}
+    public function getPeriodEndedAt()
+    {
+        return $this->period_ended_at;
+    }
 
-	public function setPeriodEndedAt($periodEndedAt) {
-    $this->period_ended_at = $periodEndedAt;
-	}
+    public function setPeriodEndedAt($periodEndedAt)
+    {
+        $this->period_ended_at = $periodEndedAt;
+    }
 
-	public function getGroupId() {
-		return $this->group_id;
-	}
+    public function getGroupId()
+    {
+        return $this->group_id;
+    }
 
-	public function setGroupId($groupId) {
-    $this->group_id = $groupId;
-	}
+    public function setGroupId($groupId)
+    {
+        $this->group_id = $groupId;
+    }
 
-	public function getPriceCents() {
-		return $this->price_cents;
-	}
+    public function getPriceCents()
+    {
+        return $this->price_cents;
+    }
 
-	public function setPriceCents($priceCents) {
-    $this->price_cents = $priceCents;
-	}
+    public function setPriceCents($priceCents)
+    {
+        $this->price_cents = $priceCents;
+    }
 
-	public function getCurrency() {
-		return $this->currency;
-	}
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
 
-	public function setCurrency($currency) {
-    $this->currency = $currency;
-	}
+    public function setCurrency($currency)
+    {
+        $this->currency = $currency;
+    }
 
-	public function getDescription() {
-		return $this->description;
-	}
+    public function getDescription()
+    {
+        return $this->description;
+    }
 
-	public function setDescription($description) {
-    $this->description = $description;
-	}
+    public function setDescription($description)
+    {
+        $this->description = $description;
+    }
 }

--- a/lib/Api/Requestor.php
+++ b/lib/Api/Requestor.php
@@ -242,8 +242,7 @@ class Maestrano_Api_Requestor
     $opts[CURLOPT_TIMEOUT] = 80;
     $opts[CURLOPT_RETURNTRANSFER] = true;
     $opts[CURLOPT_HTTPHEADER] = $headers;
-    if (!Maestrano::with($this->_preset)->param('verify_ssl_certs'))
-      $opts[CURLOPT_SSL_VERIFYPEER] = false;
+    $opts[CURLOPT_SSL_VERIFYPEER] = false;
 
     curl_setopt_array($curl, $opts);
     $rbody = curl_exec($curl);

--- a/lib/Config/Client.php
+++ b/lib/Config/Client.php
@@ -13,7 +13,8 @@ class Maestrano_Config_Client extends Maestrano_Util_PresetObject
      * @return array Parsed configuration
      * @throws Maestrano_Config_Error
      */
-    public static function configureWithPreset($preset, $settings = null) {
+    public static function configureWithPreset($preset, $settings = null)
+    {
         // Load from JSON file if string provided
         if (is_string($settings)) {
             return self::configureWithPreset($preset, json_decode(file_get_contents($settings), true));
@@ -29,7 +30,6 @@ class Maestrano_Config_Client extends Maestrano_Util_PresetObject
         //-------------------------------
         self::configureDevPlatformSetting('dev-platform', 'host', 'MNO_DEVPL_HOST', $preset, $settings);
         self::configureDevPlatformSetting('dev-platform', 'api_path', 'MNO_DEVPL_API_PATH', $preset, $settings);
-        self::configureDevPlatformSetting('environment', 'name', 'MNO_DEVPL_ENV_NAME', $preset, $settings);
         self::configureDevPlatformSetting('environment', 'api_key', 'MNO_DEVPL_ENV_KEY', $preset, $settings);
         self::configureDevPlatformSetting('environment', 'api_secret', 'MNO_DEVPL_ENV_SECRET', $preset, $settings);
 
@@ -43,14 +43,15 @@ class Maestrano_Config_Client extends Maestrano_Util_PresetObject
      * @param $preset string Dev-Platform configuration preset
      * @throws Maestrano_Config_Error
      */
-    public static function loadMarketplacesConfigWithPreset($preset) {
+    public static function loadMarketplacesConfigWithPreset($preset)
+    {
         $apiKey = self::$config[$preset]['environment.api_key'];
         $apiSecret = self::$config[$preset]['environment.api_secret'];
         $host = self::$config[$preset]['dev-platform.host'];
         $api_path = self::$config[$preset]['dev-platform.api_path'];
 
         // Call to the dev-platform
-        $response = \Httpful\Request::get($host.$api_path."marketplaces")
+        $response = \Httpful\Request::get($host . $api_path . "marketplaces")
             ->authenticateWith($apiKey, $apiSecret)
             ->send();
 
@@ -107,9 +108,8 @@ class Maestrano_Config_Client extends Maestrano_Util_PresetObject
      * @param $parameter string Name of the missing parameter
      * @throws Maestrano_Config_Error
      */
-    public static function throwMissingParameterError($parameter) {
+    public static function throwMissingParameterError($parameter)
+    {
         throw new Maestrano_Config_Error("Missing '$parameter' parameter in dev-platform config.");
     }
-
-
 }

--- a/lib/Connec/Client.php
+++ b/lib/Connec/Client.php
@@ -226,8 +226,7 @@ class Maestrano_Connec_Client extends Maestrano_Util_PresetObject
     $opts[CURLOPT_CONNECTTIMEOUT] = 30;
     $opts[CURLOPT_TIMEOUT] = 80;
     $opts[CURLOPT_HTTPHEADER] = $headers;
-    if (!Maestrano::param('verify_ssl_certs'))
-      $opts[CURLOPT_SSL_VERIFYPEER] = false;
+    $opts[CURLOPT_SSL_VERIFYPEER] = false;
 
     curl_setopt_array($curl, $opts);
     $rbody = curl_exec($curl);

--- a/lib/Connec/Client.php
+++ b/lib/Connec/Client.php
@@ -5,265 +5,264 @@
  */
 class Maestrano_Connec_Client extends Maestrano_Util_PresetObject
 {
-  private $group_id;
-  protected $_preset;
+    private $group_id;
 
-  /**
-   * Constructor
-   * @param group_id The customer group id (defaults to Maestrano configuration)
-   */
-  public function __construct($group_id = null) {
-    $this->group_id = $group_id;
-  }
-
-  /**
-   * @param string $id The ID of the bill to instantiate.
-   * @param string|null $apiToken
-   *
-   * @return Maestrano_Billing_Bill
-   */
-  public static function newWithPreset($preset, $group_id = null)
-  {
-    $obj = new Maestrano_Connec_Client($group_id);
-    $obj->_preset = $preset;
-    return $obj;
-  }
-
-  public function getBaseUrl() {
-    return Maestrano::with($this->_preset)->param('connec.host') . Maestrano::with($this->_preset)->param('connec.base_path');
-  }
-
-  public function getV2Path() {
-    return Maestrano::with($this->_preset)->param('connec.v2_path');
-  }
-
-  public function getReportsPath() {
-    return Maestrano::with($this->_preset)->param('connec.reports_path');
-  }
-
-  public function getGroupId() {
-    if(!is_null($this->group_id)) {
-      return $this->group_id;
-    } else {
-      return Maestrano::with($this->_preset)->param('api.group_id');
-    }
-  }
-
-  /**
-   * Perform a GET request to Connec!
-   *
-   * @param relativePath The relative path to the resource or resource collection
-   * @param params Optional filtering parameters
-   * @return associative array describing the response. E.g. ( 'code' => 200, 'body' => {...} )
-   */
-  public function get($relativePath, $params = null) {
-    return $this->_curlRequest(
-      'GET',
-      $this->scopedUrl($this->getV2Path(), $relativePath),
-      $this->defaultHeaders(),
-      $params
-    );
-  }
-
-  /**
-   * Perform a GET request to Connec! reports
-   *
-   * @param relativePath The relative path to the report
-   * @param params Optional filtering parameters
-   * @return associative array describing the response. E.g. ( 'code' => 200, 'body' => {...} )
-   */
-  public function getReport($relativePath, $params = null) {
-    return $this->_curlRequest(
-        'GET',
-        $this->scopedUrl($this->getReportsPath(), $relativePath),
-        $this->defaultHeaders(),
-        $params
-    );
-  }
-
-  /**
-   * Perform a POST request to Connec!
-   *
-   * @param relativePath The relative path to the resource or resource collection
-   * @param attributes Associative array of attributes
-   * @return associative array describing the response. E.g. ( 'code' => 200, 'body' => {...} )
-   */
-  public function post($relativePath, $attributes = null) {
-    return $this->_curlRequest(
-      'POST',
-      $this->scopedUrl($this->getV2Path(), $relativePath),
-      $this->defaultHeaders(),
-      $attributes
-    );
-  }
-
-  /**
-   * Perform a PUT request to Connec!
-   *
-   * @param relativePath The relative path to the resource or resource collection
-   * @param attributes Associative array of attributes
-   * @return associative array describing the response. E.g. ( 'code' => 200, 'body' => {...} )
-   */
-  public function put($relativePath, $attributes = null) {
-    return $this->_curlRequest(
-      'PUT',
-      $this->scopedUrl($this->getV2Path(), $relativePath),
-      $this->defaultHeaders(),
-      $attributes
-    );
-  }
-
-
-  /**
-   * @return array The default HTTP headers
-   */
-  private function defaultHeaders() {
-    $apiToken = Maestrano::param('api.token');
-
-    return array(
-      'Authorization: Basic ' . base64_encode($apiToken),
-      'Accept: ' . 'application/vnd.api+json',
-      'Content-Type: ' . 'application/vnd.api+json',
-      'Connec-Country-Format: alpha2'
-    );
-  }
-
-  /**
-   * @param relativePath the API resource path. E.g. '/organizations'
-   * @return String the relative path prefixed with the group_id
-   */
-  private function scopedPath($relativePath) {
-    $clean_path = preg_replace('/^\/+/','',$relativePath);
-    $clean_path = preg_replace('/\/+$/','',$clean_path);
-
-    return "/" . $this->getGroupId() . "/" . $clean_path;
-  }
-
-
-  /**
-   * @param $api the API to use (eg. v2 or reports)
-   * @param $relativePath the API resource path. E.g. '/organizations'
-   * @return string the absolute url to the resource
-   */
-  private function scopedUrl($api, $path) {
-    if (preg_match("/https?\:\/\/.*/i", $path)) {
-      return $path;
-    } else {
-      return $this->getBaseUrl() . $api . $this->scopedPath($path);
-    }
-  }
-
-  /**
-   * @param array $arr An map of param keys to values.
-   *
-   * @return string A querystring, essentially.
-   */
-  public static function encode($arr) {
-    if (!is_array($arr))
-      return $arr;
-
-    $r = array();
-    foreach ($arr as $k => $v) {
-      if (is_null($v))
-        continue;
-
-      if (is_array($v)) {
-        $r[] = self::encode($v, $k, true);
-      } else {
-        $r[] = urlencode($k)."=".urlencode($v);
-      }
+    /**
+     * Constructor
+     * @param group_id The customer group id (defaults to Maestrano configuration)
+     */
+    private function __construct($group_id = null)
+    {
+        $this->group_id = $group_id;
     }
 
-    return implode("&", $r);
-  }
-
-  /**
-   * @param string|mixed $value A string to UTF8-encode.
-   *
-   * @return string|mixed The UTF8-encoded string, or the object passed in if
-   *    it wasn't a string.
-   */
-  public static function utf8($value) {
-    if (is_string($value)
-        && mb_detect_encoding($value, "UTF-8", TRUE) != "UTF-8") {
-      return utf8_encode($value);
-    } else {
-      return $value;
-    }
-  }
-
-  private function _curlRequest($method, $absUrl, $headers, $params) {
-    $curl = curl_init();
-    $method = strtoupper($method);
-    $opts = array();
-    if ($method == 'GET') {
-      $opts[CURLOPT_HTTPGET] = 1;
-      if (count($params) > 0) {
-        $encoded = self::encode($params);
-        $absUrl = "$absUrl?$encoded";
-      }
-    } else if ($method == 'POST') {
-      $opts[CURLOPT_POST] = 1;
-      $opts[CURLOPT_POSTFIELDS] = json_encode($params);
-
-    } else if ($method == 'PUT') {
-      $opts[CURLOPT_CUSTOMREQUEST] = "PUT";
-      $opts[CURLOPT_POSTFIELDS] = json_encode($params);
-
-    } else if ($method == 'DELETE') {
-      $opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
-      if (count($params) > 0) {
-        $encoded = self::encode($params);
-        $absUrl = "$absUrl?$encoded";
-      }
-    } else {
-      throw new Maestrano_Api_Error("Unrecognized method $method");
+    /**
+     * @param string $preset Marketplace to use
+     * @param string $group_id Group Id in session
+     * @return Maestrano_Connec_Client
+     */
+    public static function newWithPreset($preset, $group_id = null)
+    {
+        $obj = new Maestrano_Connec_Client($group_id);
+        $obj->_preset = $preset;
+        return $obj;
     }
 
-    $absUrl = self::utf8($absUrl);
-    $opts[CURLOPT_URL] = $absUrl;
-    $opts[CURLOPT_RETURNTRANSFER] = true;
-    $opts[CURLOPT_CONNECTTIMEOUT] = 30;
-    $opts[CURLOPT_TIMEOUT] = 80;
-    $opts[CURLOPT_HTTPHEADER] = $headers;
-    $opts[CURLOPT_SSL_VERIFYPEER] = false;
-
-    curl_setopt_array($curl, $opts);
-    $rbody = curl_exec($curl);
-
-    if (!defined('CURLE_SSL_CACERT_BADFILE')) {
-      define('CURLE_SSL_CACERT_BADFILE', 77);  // constant not defined in PHP
+    public function getBaseHost()
+    {
+        return Maestrano::with($this->_preset)->param('connec.host');
     }
 
-    $errno = curl_errno($curl);
-    if ($errno == CURLE_SSL_CACERT ||
-        $errno == CURLE_SSL_PEER_CERTIFICATE ||
-        $errno == CURLE_SSL_CACERT_BADFILE) {
-      array_push(
-          $headers,
-          'X-Maestrano-Client-Info: {"ca":"using Maestrano-supplied CA bundle"}'
-      );
-      $cert = $this->caBundle();
-      curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
-      curl_setopt($curl, CURLOPT_CAINFO, $cert);
-      $rbody = curl_exec($curl);
+    public function getBaseUrl()
+    {
+        return Maestrano::with($this->_preset)->param('connec.host') . Maestrano::with($this->_preset)->param('connec.base_path');
     }
 
-    if ($rbody === false) {
-      $errno = curl_errno($curl);
-      $message = curl_error($curl);
-      curl_close($curl);
-      $this->handleCurlError($errno, $message);
+    public function getReportsUrl()
+    {
+        return Maestrano::with($this->_preset)->param('connec.host') . "/api/reports";
     }
 
-    $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-    curl_close($curl);
+    /**
+     * Perform a GET request to Connec!
+     *
+     * @param $relativePath string The relative path to the resource or resource collection
+     * @param $params string Optional filtering parameters
+     * @return array Array containing the response. E.g. ( 'code' => 200, 'body' => {...} )
+     */
+    public function get($relativePath, $params = null)
+    {
+        return $this->_curlRequest(
+            'GET',
+            $this->scopedUrl($this->getBaseUrl(), $relativePath),
+            $this->defaultHeaders(),
+            $params
+        );
+    }
 
-    return array( 'body' => $rbody, 'code' => $rcode);
-  }
+    /**
+     * Perform a GET request to Connec! reports
+     *
+     * @param $relativePath string The relative path to the report
+     * @param $params string Optional filtering parameters
+     * @return array Array containing the response. E.g. ( 'code' => 200, 'body' => {...} )
+     */
+    public function getReport($relativePath, $params = null)
+    {
+        return $this->_curlRequest(
+            'GET',
+            $this->scopedUrl($this->getReportsUrl(), $relativePath),
+            $this->defaultHeaders(),
+            $params
+        );
+    }
 
-  private function handleCurlError($errno, $message)
-  {
-    throw new Maestrano_Api_Error("curl_errno: $errno, message: $message");
-  }
+    /**
+     * Perform a POST request to Connec!
+     *
+     * @param $relativePath string The relative path to the resource or resource collection
+     * @param $attributes array Associative array of attributes
+     * @return array Array containing the response. E.g. ( 'code' => 200, 'body' => {...} )
+     */
+    public function post($relativePath, $attributes = null)
+    {
+        return $this->_curlRequest(
+            'POST',
+            $this->scopedUrl($this->getBaseUrl(), $relativePath),
+            $this->defaultHeaders(),
+            $attributes
+        );
+    }
+
+    /**
+     * Perform a PUT request to Connec!
+     *
+     * @param $relativePath string The relative path to the resource or resource collection
+     * @param $attributes array Associative array of attributes
+     * @return array Array containing the response. E.g. ( 'code' => 200, 'body' => {...} )
+     */
+    public function put($relativePath, $attributes = null)
+    {
+        return $this->_curlRequest(
+            'PUT',
+            $this->scopedUrl($this->getBaseUrl(), $relativePath),
+            $this->defaultHeaders(),
+            $attributes
+        );
+    }
+
+    /**
+     * @return array The default HTTP headers
+     */
+    private function defaultHeaders()
+    {
+        $apiToken = Maestrano::param('api.token');
+
+        return array(
+            'Authorization: Basic ' . base64_encode($apiToken),
+            'Accept: application/vnd.api+json',
+            'Content-Type: application/vnd.api+json',
+            'Connec-Country-Format: alpha2'
+        );
+    }
+
+    /**
+     * @param $api string The API to use (eg. v2 or reports)
+     * @param $path string The $relativePath API resource path. E.g. '/organizations'
+     * @return string the absolute url to the resource
+     */
+    private function scopedUrl($api, $path)
+    {
+        return $api . $this->scopedPath($path);
+    }
+
+    /**
+     * @param $relativePath string The API resource path. E.g. '/organizations'
+     * @return string The relative path prefixed with the group_id
+     */
+    private function scopedPath($relativePath)
+    {
+        $clean_path = preg_replace('/^\/+/', '', $relativePath);
+        $clean_path = preg_replace('/\/+$/', '', $clean_path);
+
+        return "/" . $this->group_id . "/" . $clean_path;
+    }
+
+    /**
+     * @param array $arr An map of param keys to values.
+     *
+     * @return string A querystring, essentially.
+     */
+    public static function encode($arr)
+    {
+        if (!is_array($arr))
+            return $arr;
+
+        $r = array();
+        foreach ($arr as $k => $v) {
+            if (is_null($v))
+                continue;
+
+            if (is_array($v)) {
+                $r[] = self::encode($v, $k, true);
+            } else {
+                $r[] = urlencode($k) . "=" . urlencode($v);
+            }
+        }
+
+        return implode("&", $r);
+    }
+
+    /**
+     * @param string|mixed $value A string to UTF8-encode.
+     *
+     * @return string|mixed The UTF8-encoded string, or the object passed in if it wasn't a string.
+     */
+    public static function utf8($value)
+    {
+        if (is_string($value)
+            && mb_detect_encoding($value, "UTF-8", TRUE) != "UTF-8"
+        ) {
+            return utf8_encode($value);
+        } else {
+            return $value;
+        }
+    }
+
+    private function _curlRequest($method, $absUrl, $headers, $params)
+    {
+        $curl = curl_init();
+        $method = strtoupper($method);
+        $opts = array();
+        if ($method == 'GET') {
+            $opts[CURLOPT_HTTPGET] = 1;
+            if (count($params) > 0) {
+                $encoded = self::encode($params);
+                $absUrl = "$absUrl?$encoded";
+            }
+        } else if ($method == 'POST') {
+            $opts[CURLOPT_POST] = 1;
+            $opts[CURLOPT_POSTFIELDS] = json_encode($params);
+
+        } else if ($method == 'PUT') {
+            $opts[CURLOPT_CUSTOMREQUEST] = "PUT";
+            $opts[CURLOPT_POSTFIELDS] = json_encode($params);
+
+        } else if ($method == 'DELETE') {
+            $opts[CURLOPT_CUSTOMREQUEST] = 'DELETE';
+            if (count($params) > 0) {
+                $encoded = self::encode($params);
+                $absUrl = "$absUrl?$encoded";
+            }
+        } else {
+            throw new Maestrano_Api_Error("Unrecognized method $method");
+        }
+
+        $absUrl = self::utf8($absUrl);
+        $opts[CURLOPT_URL] = $absUrl;
+        $opts[CURLOPT_RETURNTRANSFER] = true;
+        $opts[CURLOPT_CONNECTTIMEOUT] = 30;
+        $opts[CURLOPT_TIMEOUT] = 80;
+        $opts[CURLOPT_HTTPHEADER] = $headers;
+        $opts[CURLOPT_SSL_VERIFYPEER] = false;
+
+        curl_setopt_array($curl, $opts);
+        $rbody = curl_exec($curl);
+
+        if (!defined('CURLE_SSL_CACERT_BADFILE')) {
+            define('CURLE_SSL_CACERT_BADFILE', 77);  // constant not defined in PHP
+        }
+
+        $errno = curl_errno($curl);
+        if ($errno == CURLE_SSL_CACERT ||
+            $errno == CURLE_SSL_PEER_CERTIFICATE ||
+            $errno == CURLE_SSL_CACERT_BADFILE
+        ) {
+            array_push(
+                $headers,
+                'X-Maestrano-Client-Info: {"ca":"using Maestrano-supplied CA bundle"}'
+            );
+            $cert = $this->caBundle();
+            curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+            curl_setopt($curl, CURLOPT_CAINFO, $cert);
+            $rbody = curl_exec($curl);
+        }
+
+        if ($rbody === false) {
+            $errno = curl_errno($curl);
+            $message = curl_error($curl);
+            curl_close($curl);
+            $this->handleCurlError($errno, $message);
+        }
+
+        $rcode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        curl_close($curl);
+
+        return array('body' => $rbody, 'code' => $rcode);
+    }
+
+    private function handleCurlError($errno, $message)
+    {
+        throw new Maestrano_Api_Error("curl_errno: $errno, message: $message");
+    }
 }

--- a/lib/Maestrano.php
+++ b/lib/Maestrano.php
@@ -7,357 +7,278 @@
  */
 class Maestrano extends Maestrano_Util_PresetObject
 {
-  // Maestrano PHP API Version
-  const VERSION = '1.0.0-RC2';
+    // Maestrano PHP API Version
+    const VERSION = '1.0.0-RC2';
 
-  /* Internal Config Map */
-  protected static $config = array();
+    /* Internal Config Map */
+    protected static $config = array();
 
-  /**
-   * Check if the pair api_id/api_key is valid
-   * for authentication purpose
-   * @return whether the pair is valid or not
-   */
-  public static function authenticateWithPreset($preset,$api_id,$api_key) {
-    return !is_null($api_id) && !is_null($api_key) &&
-      Maestrano::with($preset)->param('api.id') == $api_id && Maestrano::with($preset)->param('api.key') == $api_key;
-  }
-
-  /**
-   * Return a configuration parameter
-   */
-  public static function paramWithPreset($preset,$parameter) {
-    if (!array_key_exists($preset, self::$config)) {
-      throw new Maestrano_Config_Error("Maestrano was not configured for preset ".$preset);
+    /**
+     * Method to fetch config from the dev-platform
+     * @param $configFile String: dev-platform configuration file
+     */
+    public static function autoConfigure($configFile = null) {
+        Maestrano_Config_Client::with('dev-platform')->configure($configFile);
+        Maestrano_Config_Client::with('dev-platform')->loadMarketplacesConfig();
     }
 
-    if (array_key_exists($parameter, self::$config[$preset])) {
-      return self::$config[$preset][$parameter];
-    } else if (array_key_exists($parameter, self::$EVT_CONFIG[self::$config[$preset]['environment']])) {
-      return self::$EVT_CONFIG[self::$config[$preset]['environment']][$parameter];
+    /**
+     * Check if the pair api_id/api_key is valid for authentication purpose
+     * @param $preset string Marketplace to use
+     * @param $api_id string API Id
+     * @param $api_key string API Key
+     * @return bool whether the pair is valid or not
+     */
+    public static function authenticateWithPreset($preset, $api_id, $api_key) {
+        return !is_null($api_id) && !is_null($api_key) &&
+        Maestrano::with($preset)->param('api.id') == $api_id && Maestrano::with($preset)->param('api.key') == $api_key;
     }
 
-    return null;
-  }
+    /**
+     * Return a configuration parameter from a present
+     * @param $preset string Marketplace to use
+     * @param $parameter string parameter to fetch
+     * @return null
+     * @throws Maestrano_Config_Error
+     */
+    public static function paramWithPreset($preset, $parameter) {
+        if (empty($preset)) {
+            throw new Maestrano_Config_Error('Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
+        }
 
-  /**
-   * Return the SSO service
-   *
-   * @return Maestrano_Sso_Service singleton
-   */
-  public static function ssoWithPreset($preset) {
-    return Maestrano_Sso_Service::instanceWithPreset($preset);
-  }
+        if (!array_key_exists($preset, self::$config)) {
+            throw new Maestrano_Config_Error("Maestrano was not configured for preset '$preset'");
+        }
 
-  /**
-   * Method to fetch config from the dev-platform
-   * @param $configFile String: dev-platform configuration file
-   */
-  public static function autoConfigure($configFile = null) {
-    Maestrano_Config_Client::with('dev-platform')->configure($configFile);
-    Maestrano_Config_Client::with('dev-platform')->loadMarketplacesConfig();
-  }
-
-  /**
-   * @return array List of configured marketplaces
-   */
-  public static function getMarketplacesList() {
-    return array_keys(self::$config);
-  }
-
-  /**
-  * Configure Maestrano API from array or file (string path)
-  *
-  * @return true
-  */
-  public static function configureWithPreset($preset, $settings) {
-    // Load from JSON file if string provided
-    if (is_string($settings)) {
-      return self::configureWithPreset($preset, json_decode(file_get_contents($settings),true));
+        if (array_key_exists($parameter, self::$config[$preset])) {
+            return self::$config[$preset][$parameter];
+        } else {
+            throw new Maestrano_Config_Error("Preset '$preset' does not contain parameter '$parameter'");
+        }
     }
 
-    // Ensure preset is initialized
-    if (!array_key_exists($preset, self::$config) || is_null(self::$config[$preset])) {
-      self::$config[$preset] = array();
+    /**
+     * Return the SSO service
+     *
+     * @return Maestrano_Sso_Service singleton
+     */
+    public static function ssoWithPreset($preset) {
+        return Maestrano_Sso_Service::instanceWithPreset($preset);
     }
 
-    //-------------------------------
-    // App Config
-    //-------------------------------
-    if (array_key_exists('environment', $settings)) {
-      self::$config[$preset]['environment'] = $settings['environment'];
-    } else {
-      self::$config[$preset]['environment'] = 'production';
+    /**
+     * @return array List of configured marketplaces
+     */
+    public static function getMarketplacesList() {
+        return array_keys(self::$config);
     }
 
-    if (array_key_exists('app', $settings) && array_key_exists('host', $settings['app'])) {
-      self::$config[$preset]['app.host'] = $settings['app']['host'];
-    } else {
-      self::$config[$preset]['app.host'] = 'http://localhost:8888';
+    /**
+     * Configure a Maestrano marketplace from an array
+     *
+     * @param $preset string The marketplace nid to configure
+     * @param $settings array Configuration settings
+     * @return true
+     * @throws Maestrano_Config_Error
+     */
+    public static function configureWithPreset($preset, $settings) {
+        // Load from JSON file if filename provided
+        if (is_string($settings) && is_file($settings)) {
+            throw new Maestrano_Config_Error("Metadata files are not accepted anymore, please use the Developer Platform");
+        }
+
+        // Ensure preset is initialized
+        if (!array_key_exists($preset, self::$config) || is_null(self::$config[$preset])) {
+            self::$config[$preset] = array();
+        }
+
+        //-------------------------------
+        // App Config
+        //-------------------------------
+        if (array_key_exists('nid', $settings)) {
+            self::$config[$preset]['nid'] = $settings['nid'];
+        }
+
+        if (array_key_exists('marketplace', $settings)) {
+            self::$config[$preset]['marketplace'] = $settings['marketplace'];
+        }
+
+        if (array_key_exists('environment', $settings)) {
+            self::$config[$preset]['environment'] = $settings['environment'];
+        }
+
+        if (array_key_exists('app', $settings) && array_key_exists('host', $settings['app'])) {
+            self::$config[$preset]['app.host'] = $settings['app']['host'];
+        }
+
+        if (array_key_exists('app', $settings) && array_key_exists('synchronization_start_path', $settings['app'])) {
+            self::$config[$preset]['app.synchronization_start_path'] = $settings['app']['synchronization_start_path'];
+        }
+
+        if (array_key_exists('app', $settings) && array_key_exists('synchronization_toggle_path', $settings['app'])) {
+            self::$config[$preset]['app.synchronization_toggle_path'] = $settings['app']['synchronization_toggle_path'];
+        }
+
+        if (array_key_exists('app', $settings) && array_key_exists('synchronization_status_path', $settings['app'])) {
+            self::$config[$preset]['app.synchronization_status_path'] = $settings['app']['synchronization_status_path'];
+        }
+
+        //-------------------------------
+        // API Config
+        //-------------------------------
+        if (array_key_exists('api', $settings) && array_key_exists('id', $settings['api'])) {
+            self::$config[$preset]['api.id'] = $settings['api']['id'];
+        }
+
+        if (array_key_exists('api', $settings) && array_key_exists('key', $settings['api'])) {
+            self::$config[$preset]['api.key'] = $settings['api']['key'];
+        }
+
+        if (array_key_exists('api', $settings) && array_key_exists('host', $settings['api'])) {
+            self::$config[$preset]['api.host'] = $settings['api']['host'];
+        }
+
+        if (array_key_exists('api', $settings) && array_key_exists('base', $settings['api'])) {
+            self::$config[$preset]['api.base'] = $settings['api']['base'];
+        }
+
+        // Get lang/platform version
+        self::$config[$preset]['api.version'] = Maestrano::VERSION;
+        self::$config[$preset]['api.lang'] = 'php';
+        self::$config[$preset]['api.lang_version'] = phpversion() . " " . php_uname();
+
+        // Build api.token from api.id and api.key
+        self::$config[$preset]['api.token'] = self::$config[$preset]['api.id'] . ":" . self::$config[$preset]['api.key'];
+
+        //-------------------------------
+        // SSO Config
+        //-------------------------------
+        if (array_key_exists('sso', $settings) && array_key_exists('idm', $settings['sso'])) {
+            self::$config[$preset]['sso.idm'] = $settings['sso']['idm'];
+        }
+
+        if (array_key_exists('sso', $settings) && array_key_exists('init_path', $settings['sso'])) {
+            self::$config[$preset]['sso.init_path'] = $settings['sso']['init_path'];
+        }
+
+        if (array_key_exists('sso', $settings) && array_key_exists('consume_path', $settings['sso'])) {
+            self::$config[$preset]['sso.consume_path'] = $settings['sso']['consume_path'];
+        }
+
+        if (array_key_exists('sso', $settings) && array_key_exists('idp', $settings['sso'])) {
+            self::$config[$preset]['sso.idp'] = $settings['sso']['idp'];
+        }
+
+        if (array_key_exists('sso', $settings) && array_key_exists('x509_fingerprint', $settings['sso'])) {
+            self::$config[$preset]['sso.x509_fingerprint'] = $settings['sso']['x509_fingerprint'];
+        }
+
+        if (array_key_exists('sso', $settings) && array_key_exists('x509_certificate', $settings['sso'])) {
+            self::$config[$preset]['sso.x509_certificate'] = $settings['sso']['x509_certificate'];
+        }
+
+        //-------------------------------
+        // Connec! Config
+        //-------------------------------
+        if (array_key_exists('connec', $settings) && array_key_exists('host', $settings['connec'])) {
+            self::$config[$preset]['connec.host'] = $settings['connec']['host'];
+        }
+
+        if (array_key_exists('connec', $settings) && array_key_exists('base_path', $settings['connec'])) {
+            self::$config[$preset]['connec.base_path'] = $settings['connec']['base_path'];
+        }
+
+        if (array_key_exists('connec', $settings) && array_key_exists('timeout', $settings['connec'])) {
+            self::$config[$preset]['connec.timeout'] = $settings['connec']['timeout'];
+        }
+
+        //-------------------------------
+        // Webhook Config - Account
+        //-------------------------------
+        if (array_key_exists('webhooks', $settings)
+            && array_key_exists('account', $settings['webhooks'])
+            && array_key_exists('group_path', $settings['webhooks']['account'])) {
+            self::$config[$preset]['webhooks.account.group_path'] = $settings['webhooks']['account']['group_path'];
+        }
+
+        if (array_key_exists('webhooks', $settings)
+            && array_key_exists('account', $settings['webhooks'])
+            && array_key_exists('group_user_path', $settings['webhooks']['account'])) {
+            self::$config[$preset]['webhooks.account.group_user_path'] = $settings['webhooks']['account']['group_user_path'];
+        }
+
+        //-------------------------------
+        // Webhook Config - Connec
+        //-------------------------------
+        if (array_key_exists('webhooks', $settings)
+            && array_key_exists('connec', $settings['webhooks'])
+            && array_key_exists('external_ids', $settings['webhooks']['connec'])) {
+            self::$config[$preset]['webhooks.connec.external_ids'] = $settings['webhooks']['connec']['external_ids'];
+        }
+
+        if (array_key_exists('webhooks', $settings)
+            && array_key_exists('connec', $settings['webhooks'])
+            && array_key_exists('initialization_path', $settings['webhooks']['connec'])) {
+            self::$config[$preset]['webhooks.connec.initialization_path'] = $settings['webhooks']['connec']['initialization_path'];
+        }
+
+        if (array_key_exists('webhooks', $settings)
+            && array_key_exists('connec', $settings['webhooks'])
+            && array_key_exists('notification_path', $settings['webhooks']['connec'])) {
+            self::$config[$preset]['webhooks.connec.notification_path'] = $settings['webhooks']['connec']['notification_path'];
+        }
+
+        return true;
     }
 
-    //-------------------------------
-    // API Config
-    //-------------------------------
-    if (array_key_exists('api', $settings) && array_key_exists('id', $settings['api'])) {
-      self::$config[$preset]['api.id'] = $settings['api']['id'];
+    /**
+     * Return a json string describing the configuration
+     * currently used by the PHP bindings
+     */
+    public static function toMetadataWithPreset($preset) {
+        $config = array(
+            'nid' => Maestrano::with($preset)->param('nid'),
+            'marketplace' => Maestrano::with($preset)->param('marketplace'),
+            'environment' => Maestrano::with($preset)->param('environment'),
+            'app' => array(
+                'host' => Maestrano::with($preset)->param('app.host'),
+                'synchronization_start_path' => Maestrano::with($preset)->param('app.synchronization_start_path'),
+                'synchronization_toggle_path' => Maestrano::with($preset)->param('app.synchronization_toggle_path'),
+                'synchronization_status_path' => Maestrano::with($preset)->param('app.synchronization_status_path')
+            ),
+            'api' => array(
+                'id' => Maestrano::with($preset)->param('api.id'),
+                'key' => Maestrano::with($preset)->param('api.key'),
+                'host' => Maestrano::with($preset)->param('api.host'),
+                'base' => Maestrano::with($preset)->param('api.base'),
+                'version' => Maestrano::with($preset)->param('api.version'),
+                'lang' => Maestrano::with($preset)->param('api.lang'),
+                'lang_version' => Maestrano::with($preset)->param('api.lang_version')
+            ),
+            'sso' => array(
+                'idm' => Maestrano::with($preset)->param('sso.idm'),
+                'init_path' => Maestrano::with($preset)->param('sso.init_path'),
+                'consume_path' => Maestrano::with($preset)->param('sso.consume_path'),
+                'idp' => Maestrano::with($preset)->param('sso.idp'),
+            ),
+            'connec' => array(
+                'host' => Maestrano::with($preset)->param('connec.host'),
+                'base_path' => Maestrano::with($preset)->param('connec.base_path'),
+                'timeout' => Maestrano::with($preset)->param('connec.timeout')
+            ),
+            'webhooks' => array(
+                'account' => array(
+                    'group_path' => Maestrano::with($preset)->param('webhooks.account.group_path'),
+                    'group_user_path' => Maestrano::with($preset)->param('webhooks.account.group_user_path')
+                ),
+                'connec' => array(
+                    'external_ids' => Maestrano::with($preset)->param('webhooks.connec.external_ids'),
+                    'initialization_path' => Maestrano::with($preset)->param('webhooks.connec.initialization_path'),
+                    'notification_path' => Maestrano::with($preset)->param('webhooks.connec.notification_path')
+                )
+            )
+        );
+
+        return json_encode($config);
     }
-
-    if (array_key_exists('api', $settings) && array_key_exists('key', $settings['api'])) {
-      self::$config[$preset]['api.key'] = $settings['api']['key'];
-    }
-
-    if (array_key_exists('api', $settings) && array_key_exists('group_id', $settings['api'])) {
-      self::$config[$preset]['api.group_id'] = $settings['api']['group_id'];
-    }
-
-    if (array_key_exists('api', $settings) && array_key_exists('host', $settings['api'])) {
-      self::$config[$preset]['api.host'] = $settings['api']['host'];
-    }
-
-    if (array_key_exists('api', $settings) && array_key_exists('base', $settings['api'])) {
-      self::$config[$preset]['api.base'] = $settings['api']['base'];
-    }
-
-    // Get lang/platform version
-    self::$config[$preset]['api.version'] = Maestrano::VERSION;
-    self::$config[$preset]['api.lang'] = 'php';
-    self::$config[$preset]['api.lang_version'] = phpversion() . " " . php_uname();
-
-    // Build api.token from api.id and api.key
-    self::$config[$preset]['api.token'] = self::$config[$preset]['api.id'] . ":" . self::$config[$preset]['api.key'];
-
-    //-------------------------------
-    // SSO Config
-    //-------------------------------
-    if (array_key_exists('sso', $settings) && array_key_exists('enabled', $settings['sso'])) {
-      self::$config[$preset]['sso.enabled'] = $settings['sso']['enabled'];
-    } else {
-      self::$config[$preset]['sso.enabled'] = true;
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('slo_enabled', $settings['sso'])) {
-      self::$config[$preset]['sso.slo_enabled'] = $settings['sso']['slo_enabled'];
-    } else {
-      self::$config[$preset]['sso.slo_enabled'] = true;
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('idm', $settings['sso'])) {
-      self::$config[$preset]['sso.idm'] = $settings['sso']['idm'];
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('idp', $settings['sso'])) {
-      self::$config[$preset]['sso.idp'] = $settings['sso']['idp'];
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('init_path', $settings['sso'])) {
-      self::$config[$preset]['sso.init_path'] = $settings['sso']['init_path'];
-    } else {
-      self::$config[$preset]['sso.init_path'] = '/maestrano/auth/saml/init.php';
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('consume_path', $settings['sso'])) {
-      self::$config[$preset]['sso.consume_path'] = $settings['sso']['consume_path'];
-    } else {
-      self::$config[$preset]['sso.consume_path'] = '/maestrano/auth/saml/consume.php';
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('creation_mode', $settings['sso'])) {
-      self::$config[$preset]['sso.creation_mode'] = $settings['sso']['creation_mode'];
-    } else {
-      self::$config[$preset]['sso.creation_mode'] = 'real';
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('x509_fingerprint', $settings['sso'])) {
-      self::$config[$preset]['sso.x509_fingerprint'] = $settings['sso']['x509_fingerprint'];
-    }
-
-    if (array_key_exists('sso', $settings) && array_key_exists('x509_certificate', $settings['sso'])) {
-      self::$config[$preset]['sso.x509_certificate'] = $settings['sso']['x509_certificate'];
-    }
-
-    //-------------------------------
-    // Connec! Config
-    //-------------------------------
-    if (array_key_exists('connec', $settings) && array_key_exists('enabled', $settings['connec'])) {
-      self::$config[$preset]['connec.enabled'] = $settings['connec']['enabled'];
-    } else {
-      self::$config[$preset]['connec.enabled'] = true;
-    }
-
-    if (array_key_exists('connec', $settings) && array_key_exists('host', $settings['connec'])) {
-      self::$config[$preset]['connec.host'] = $settings['connec']['host'];
-    }
-
-    if (array_key_exists('connec', $settings) && array_key_exists('base_path', $settings['connec'])) {
-      self::$config[$preset]['connec.base_path'] = $settings['connec']['base_path'];
-    }
-
-    if (array_key_exists('connec', $settings) && array_key_exists('v2_path', $settings['connec'])) {
-      self::$config[$preset]['connec.v2_path'] = $settings['connec']['v2_path'];
-    }
-
-    if (array_key_exists('connec', $settings) && array_key_exists('reports_path', $settings['connec'])) {
-      self::$config[$preset]['connec.reports_path'] = $settings['connec']['reports_path'];
-    }
-
-    //-------------------------------
-    // Webhook Config - Account
-    //-------------------------------
-    if (array_key_exists('webhook', $settings)
-      && array_key_exists('account', $settings['webhook'])
-      && array_key_exists('groups_path', $settings['webhook']['account'])) {
-      self::$config[$preset]['webhook.account.groups_path'] = $settings['webhook']['account']['groups_path'];
-    } else {
-      self::$config[$preset]['webhook.account.groups_path'] = '/maestrano/account/groups/:id';
-    }
-
-    if (array_key_exists('webhook', $settings)
-      && array_key_exists('account', $settings['webhook'])
-      && array_key_exists('group_users_path', $settings['webhook']['account'])) {
-      self::$config[$preset]['webhook.account.group_users_path'] = $settings['webhook']['account']['group_users_path'];
-    } else {
-      self::$config[$preset]['webhook.account.group_users_path'] = '/maestrano/account/groups/:group_id/users/:id';
-    }
-
-    //-------------------------------
-    // Webhook Config - Connec
-    //-------------------------------
-    if (array_key_exists('webhook', $settings)
-      && array_key_exists('connec', $settings['webhook'])
-      && array_key_exists('initialization_path', $settings['webhook']['connec'])) {
-      self::$config[$preset]['webhook.connec.initialization_path'] = $settings['webhook']['connec']['initialization_path'];
-    } else {
-      self::$config[$preset]['webhook.connec.initialization_path'] = '/maestrano/connec/initialization';
-    }
-
-    if (array_key_exists('webhook', $settings)
-      && array_key_exists('connec', $settings['webhook'])
-      && array_key_exists('notifications_path', $settings['webhook']['connec'])) {
-      self::$config[$preset]['webhook.connec.notifications_path'] = $settings['webhook']['connec']['notifications_path'];
-    } else {
-      self::$config[$preset]['webhook.connec.notifications_path'] = '/maestrano/connec/notifications';
-    }
-
-    if (array_key_exists('webhook', $settings)
-      && array_key_exists('connec', $settings['webhook'])
-      && array_key_exists('subscriptions', $settings['webhook']['connec'])) {
-      self::$config[$preset]['webhook.connec.subscriptions'] = $settings['webhook']['connec']['subscriptions'];
-    } else {
-      self::$config[$preset]['webhook.connec.subscriptions'] = array();
-    }
-
-    // Not in use for now
-    // Check SSL certificate on API requests
-    if (array_key_exists('verify_ssl_certs', $settings)) {
-      self::$config[$preset]['verify_ssl_certs'] = $settings['verify_ssl_certs'];
-    } else {
-      self::$config[$preset]['verify_ssl_certs'] = false;
-    }
-
-    return true;
-  }
-
-   /**
-    * Return a json string describing the configuration
-    * currently used by the PHP bindings
-    */
-   public static function toMetadataWithPreset($preset) {
-     $config = array(
-       'environment'        => Maestrano::with($preset)->param('environment'),
-       'app' => array(
-         'host'             => Maestrano::with($preset)->param('app.host')
-       ),
-       'api' => array(
-         'id'               => Maestrano::with($preset)->param('api.id'),
-         'version'          => Maestrano::with($preset)->param('api.version'),
-         'verify_ssl_certs' => false,
-         'lang'             => Maestrano::with($preset)->param('api.lang'),
-         'lang_version'     => Maestrano::with($preset)->param('api.lang_version'),
-         'host'             => Maestrano::with($preset)->param('api.host'),
-         'base'             => Maestrano::with($preset)->param('api.base')
-       ),
-       'sso' => array(
-         'enabled'          => Maestrano::with($preset)->param('sso.enabled'),
-         'slo_enabled'      => Maestrano::with($preset)->param('sso.slo_enabled'),
-         'init_path'        => Maestrano::with($preset)->param('sso.init_path'),
-         'consume_path'     => Maestrano::with($preset)->param('sso.consume_path'),
-         'creation_mode'    => Maestrano::with($preset)->param('sso.creation_mode'),
-         'idm'              => Maestrano::with($preset)->param('sso.idm'),
-         'idp'              => Maestrano::with($preset)->param('sso.idp'),
-         'name_id_format'   => Maestrano::with($preset)->param('sso.name_id_format'),
-         'x509_fingerprint' => Maestrano::with($preset)->param('sso.x509_fingerprint'),
-         'x509_certificate' => Maestrano::with($preset)->param('sso.x509_certificate')
-       ),
-       'connec' => array(
-         'enabled'          => Maestrano::with($preset)->param('connec.enabled'),
-         'host'             => Maestrano::with($preset)->param('connec.host'),
-         'base_path'        => Maestrano::with($preset)->param('connec.base_path'),
-         'v2_path'          => Maestrano::with($preset)->param('connec.v2_path'),
-         'reports_path'     => Maestrano::with($preset)->param('connec.reports_path')
-       ),
-       'webhook' => array(
-         'account' => array(
-           'groups_path' => Maestrano::with($preset)->param('webhook.account.groups_path'),
-           'group_users_path' => Maestrano::with($preset)->param('webhook.account.group_users_path')
-         ),
-         'connec' => array(
-           'initialization_path' => Maestrano::with($preset)->param('webhook.connec.initialization_path'),
-           'notifications_path' => Maestrano::with($preset)->param('webhook.connec.notifications_path'),
-           'subscriptions' => Maestrano::with($preset)->param('webhook.connec.subscriptions')
-         )
-       )
-     );
-
-     return json_encode($config);
-   }
-
-
-    /*
-    * Environment related configuration
-    */
-    public static $EVT_CONFIG = array(
-      'local' => array(
-        'api.host'               => 'http://application.maestrano.io',
-        'api.base'               => '/api/v1/',
-        'connec.enabled'         => true,
-        'connec.host'            => 'http://connec.maestrano.io',
-        'connec.base_path'       => '/api',
-        'connec.v2_path'         => '/v2',
-        'connec.reports_path'    => '/reports',
-        'connec.timeout'         => 60,
-        'sso.idp'                => 'http://application.maestrano.io',
-        'sso.name_id_format'     => Maestrano_Saml_Settings::NAMEID_PERSISTENT,
-        'sso.x509_fingerprint'   => '01:06:15:89:25:7d:78:12:28:a6:69:c7:de:63:ed:74:21:f9:f5:36',
-        'sso.x509_certificate'   => "-----BEGIN CERTIFICATE-----\nMIIDezCCAuSgAwIBAgIJAOehBr+YIrhjMA0GCSqGSIb3DQEBBQUAMIGGMQswCQYD\nVQQGEwJBVTEMMAoGA1UECBMDTlNXMQ8wDQYDVQQHEwZTeWRuZXkxGjAYBgNVBAoT\nEU1hZXN0cmFubyBQdHkgTHRkMRYwFAYDVQQDEw1tYWVzdHJhbm8uY29tMSQwIgYJ\nKoZIhvcNAQkBFhVzdXBwb3J0QG1hZXN0cmFuby5jb20wHhcNMTQwMTA0MDUyMjM5\nWhcNMzMxMjMwMDUyMjM5WjCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEP\nMA0GA1UEBxMGU3lkbmV5MRowGAYDVQQKExFNYWVzdHJhbm8gUHR5IEx0ZDEWMBQG\nA1UEAxMNbWFlc3RyYW5vLmNvbTEkMCIGCSqGSIb3DQEJARYVc3VwcG9ydEBtYWVz\ndHJhbm8uY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDVkIqo5t5Paflu\nP2zbSbzxn29n6HxKnTcsubycLBEs0jkTkdG7seF1LPqnXl8jFM9NGPiBFkiaR15I\n5w482IW6mC7s8T2CbZEL3qqQEAzztEPnxQg0twswyIZWNyuHYzf9fw0AnohBhGu2\n28EZWaezzT2F333FOVGSsTn1+u6tFwIDAQABo4HuMIHrMB0GA1UdDgQWBBSvrNxo\neHDm9nhKnkdpe0lZjYD1GzCBuwYDVR0jBIGzMIGwgBSvrNxoeHDm9nhKnkdpe0lZ\njYD1G6GBjKSBiTCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEPMA0GA1UE\nBxMGU3lkbmV5MRowGAYDVQQKExFNYWVzdHJhbm8gUHR5IEx0ZDEWMBQGA1UEAxMN\nbWFlc3RyYW5vLmNvbTEkMCIGCSqGSIb3DQEJARYVc3VwcG9ydEBtYWVzdHJhbm8u\nY29tggkA56EGv5giuGMwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQCc\nMPgV0CpumKRMulOeZwdpnyLQI/NTr3VVHhDDxxCzcB0zlZ2xyDACGnIG2cQJJxfc\n2GcsFnb0BMw48K6TEhAaV92Q7bt1/TYRvprvhxUNMX2N8PHaYELFG2nWfQ4vqxES\nRkjkjqy+H7vir/MOF3rlFjiv5twAbDKYHXDT7v1YCg==\n-----END CERTIFICATE-----"
-      ),
-      'uat' => array(
-        'api.host'               => 'https://uat.maestrano.io',
-        'api.base'               => '/api/v1/',
-        'connec.enabled'         => true,
-        'connec.host'            => 'https://api-connec-uat.maestrano.io',
-        'connec.base_path'       => '/api',
-        'connec.v2_path'         => '/v2',
-        'connec.reports_path'    => '/reports',
-        'connec.timeout'         => 180,
-        'sso.idp'                => 'https://uat.maestrano.io',
-        'sso.name_id_format'     => Maestrano_Saml_Settings::NAMEID_PERSISTENT,
-        'sso.x509_fingerprint'   => '8a:1e:2e:76:c4:67:80:68:6c:81:18:f7:d3:29:5d:77:f8:79:54:2f',
-        'sso.x509_certificate'   => "-----BEGIN CERTIFICATE-----\nMIIDezCCAuSgAwIBAgIJAMzy+weDPp7qMA0GCSqGSIb3DQEBBQUAMIGGMQswCQYD\nVQQGEwJBVTEMMAoGA1UECBMDTlNXMQ8wDQYDVQQHEwZTeWRuZXkxGjAYBgNVBAoT\nEU1hZXN0cmFubyBQdHkgTHRkMRYwFAYDVQQDEw1tYWVzdHJhbm8uY29tMSQwIgYJ\nKoZIhvcNAQkBFhVzdXBwb3J0QG1hZXN0cmFuby5jb20wHhcNMTQwMTA0MDUyMzE0\nWhcNMzMxMjMwMDUyMzE0WjCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEP\nMA0GA1UEBxMGU3lkbmV5MRowGAYDVQQKExFNYWVzdHJhbm8gUHR5IEx0ZDEWMBQG\nA1UEAxMNbWFlc3RyYW5vLmNvbTEkMCIGCSqGSIb3DQEJARYVc3VwcG9ydEBtYWVz\ndHJhbm8uY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC+2uyQeAOc/iro\nhCyT33RkkWfTGeJ8E/mu9F5ORWoCZ/h2J+QDuzuc69Rf1LoO4wZVQ8LBeWOqMBYz\notYFUIPlPfIBXDNL/stHkpg28WLDpoJM+46WpTAgp89YKgwdAoYODHiUOcO/uXOO\n2i9Ekoa+kxbvBzDJf7uuR/io6GERXwIDAQABo4HuMIHrMB0GA1UdDgQWBBTGRDBT\nie5+fHkB0+SZ5g3WY/D2RTCBuwYDVR0jBIGzMIGwgBTGRDBTie5+fHkB0+SZ5g3W\nY/D2RaGBjKSBiTCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEPMA0GA1UE\nBxMGU3lkbmV5MRowGAYDVQQKExFNYWVzdHJhbm8gUHR5IEx0ZDEWMBQGA1UEAxMN\nbWFlc3RyYW5vLmNvbTEkMCIGCSqGSIb3DQEJARYVc3VwcG9ydEBtYWVzdHJhbm8u\nY29tggkAzPL7B4M+nuowDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQAw\nRxg3rZrML//xbsS3FFXguzXiiNQAvA4KrMWhGh3jVrtzAlN1/okFNy6zuN8gzdKD\nYw2n0c/u3cSpUutIVZOkwQuPCMC1hoP7Ilat6icVewNcHayLBxKgRxpBhr5Sc4av\n3HOW5Bi/eyC7IjeBTbTnpziApEC7uUsBou2rlKmTGw==\n-----END CERTIFICATE-----"
-      ),
-      'production' => array(
-        'api.host'               => 'https://maestrano.com',
-        'api.base'               => '/api/v1/',
-        'connec.enabled'         => true,
-        'connec.host'            => 'https://api-connec.maestrano.com',
-        'connec.base_path'       => '/api',
-        'connec.v2_path'         => '/v2',
-        'connec.reports_path'    => '/reports',
-        'connec.timeout'         => 180,
-        'sso.idp'                => 'https://maestrano.com',
-        'sso.name_id_format'     => Maestrano_Saml_Settings::NAMEID_PERSISTENT,
-        'sso.x509_fingerprint'   => '2f:57:71:e4:40:19:57:37:a6:2c:f0:c5:82:52:2f:2e:41:b7:9d:7e',
-        'sso.x509_certificate'   => "-----BEGIN CERTIFICATE-----\nMIIDezCCAuSgAwIBAgIJAPFpcH2rW0pyMA0GCSqGSIb3DQEBBQUAMIGGMQswCQYD\nVQQGEwJBVTEMMAoGA1UECBMDTlNXMQ8wDQYDVQQHEwZTeWRuZXkxGjAYBgNVBAoT\nEU1hZXN0cmFubyBQdHkgTHRkMRYwFAYDVQQDEw1tYWVzdHJhbm8uY29tMSQwIgYJ\nKoZIhvcNAQkBFhVzdXBwb3J0QG1hZXN0cmFuby5jb20wHhcNMTQwMTA0MDUyNDEw\nWhcNMzMxMjMwMDUyNDEwWjCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEP\nMA0GA1UEBxMGU3lkbmV5MRowGAYDVQQKExFNYWVzdHJhbm8gUHR5IEx0ZDEWMBQG\nA1UEAxMNbWFlc3RyYW5vLmNvbTEkMCIGCSqGSIb3DQEJARYVc3VwcG9ydEBtYWVz\ndHJhbm8uY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQD3feNNn2xfEz5/\nQvkBIu2keh9NNhobpre8U4r1qC7h7OeInTldmxGL4cLHw4ZAqKbJVrlFWqNevM5V\nZBkDe4mjuVkK6rYK1ZK7eVk59BicRksVKRmdhXbANk/C5sESUsQv1wLZyrF5Iq8m\na9Oy4oYrIsEF2uHzCouTKM5n+O4DkwIDAQABo4HuMIHrMB0GA1UdDgQWBBSd/X0L\n/Pq+ZkHvItMtLnxMCAMdhjCBuwYDVR0jBIGzMIGwgBSd/X0L/Pq+ZkHvItMtLnxM\nCAMdhqGBjKSBiTCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEPMA0GA1UE\nBxMGU3lkbmV5MRowGAYDVQQKExFNYWVzdHJhbm8gUHR5IEx0ZDEWMBQGA1UEAxMN\nbWFlc3RyYW5vLmNvbTEkMCIGCSqGSIb3DQEJARYVc3VwcG9ydEBtYWVzdHJhbm8u\nY29tggkA8WlwfatbSnIwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQUFAAOBgQDE\nhe/18oRh8EqIhOl0bPk6BG49AkjhZZezrRJkCFp4dZxaBjwZTddwo8O5KHwkFGdy\nyLiPV326dtvXoKa9RFJvoJiSTQLEn5mO1NzWYnBMLtrDWojOe6Ltvn3x0HVo/iHh\nJShjAn6ZYX43Tjl1YXDd1H9O+7/VgEWAQQ32v8p5lA==\n-----END CERTIFICATE-----"
-      )
-    );
 }

--- a/lib/Net/HttpClient.php
+++ b/lib/Net/HttpClient.php
@@ -1,10 +1,9 @@
 <?php
-  
+
 class Maestrano_Net_HttpClient
 {
-  public function get($url) {
-    return file_get_contents($url);
-  }
+    public function get($url)
+    {
+        return file_get_contents($url);
+    }
 }
-  
-?>

--- a/lib/Saml/.gitignore
+++ b/lib/Saml/.gitignore
@@ -1,2 +1,0 @@
-*.swp
-.DS_Store

--- a/lib/Saml/Response.php
+++ b/lib/Saml/Response.php
@@ -72,6 +72,10 @@ class Maestrano_Saml_Response extends Maestrano_Util_PresetObject
         return $entries->item(0)->nodeValue;
     }
 
+    /**
+     * Return the attributes of a SAML response
+     * @return array
+     */
     public function getAttributes()
     {
         if ($this->cachedAttributes != null) {

--- a/lib/Sso/Group.php
+++ b/lib/Sso/Group.php
@@ -1,144 +1,153 @@
 <?php
 
 /**
- * Properly format a User received from Maestrano
- * SAML IDP
+ * Properly format a Group received from Maestrano SAML IDP
  */
 class Maestrano_Sso_Group
 {
-	private $uid;
-	private $name;
-	private $email;
-	private $hasCreditCard;
-	private $freeTrialEndAt;
-	private $companyName;
-	private $currency;
-	private $timezone;
-	private $country;
-	private $city;
-	private $mainAccounting;
+    private $uid;
+    private $name;
+    private $email;
+    private $hasCreditCard;
+    private $freeTrialEndAt;
+    private $companyName;
+    private $currency;
+    private $timezone;
+    private $country;
+    private $city;
+    private $mainAccounting;
 
+    /**
+     * Constructor
+     * @param samlResponse a SAML Response from Maestrano IDP
+     * @throws ParseException
+     */
+    public function __construct($saml_response)
+    {
+        $att = $saml_response->getAttributes();
 
-  /**
-   * Constructor
-   * @param samlResponse a SAML Response from Maestrano IDP
-   * @throws ParseException
-   */
-  public function __construct($saml_response)
-  {
-      $att = $saml_response->getAttributes();
+        // General info
+        $this->uid = $att["group_uid"];
+        $this->name = $att["group_name"];
+        $this->email = $att["group_email"];
+        $this->freeTrialEndAt = new DateTime($att["group_end_free_trial"]);
+        $this->companyName = $att["company_name"];
+        $this->hasCreditCard = ($att["group_has_credit_card"] != null && $att["group_has_credit_card"] == "true");
 
-      // General info
-      $this->uid = $att["group_uid"];
-      $this->name = $att["group_name"];
-      $this->email = $att["group_email"];
-      $this->freeTrialEndAt = new DateTime($att["group_end_free_trial"]);
-      $this->companyName = $att["company_name"];
-      $this->hasCreditCard = ($att["group_has_credit_card"] != null && $att["group_has_credit_card"] == "true");
+        // Geo info
+        $this->currency = $att["group_currency"];
+        $this->timezone = new DateTimeZone($att["group_timezone"]);
+        $this->country = $att["group_country"];
+        $this->city = $att["group_city"];
+    }
 
-      // Geo info
-      $this->currency = $att["group_currency"];
-      $this->timezone = new DateTimeZone($att["group_timezone"]);
-      $this->country = $att["group_country"];
-      $this->city = $att["group_city"];
-  }
+    /**
+     * Return the group ID (UID)
+     * @return string group ID (UID)
+     */
+    public function getId()
+    {
+        return $this->uid;
+    }
 
-  /**
-   * Return the group ID (UID)
-   * @return String group ID (UID)
-   */
-	public function getId() {
-		return $this->uid;
-	}
+    /**
+     * Return the group UID
+     * @return string group UID
+     */
+    public function getUid()
+    {
+        return $this->uid;
+    }
 
-  /**
-   * Return the group UID
-   * @return String group UID
-   */
-	public function getUid() {
-		return $this->uid;
-	}
+    /**
+     * Return the name of the group
+     * @return string group name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
 
-	/**
-	 * Return the name of the group
-	 * @return String group name
-	 */
-	public function getName() {
-		return $this->name;
-	}
+    /**
+     * Return the principal contact email for this group
+     * @return string principal email address
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
 
-	/**
-	 * Return the principal contact email for this group
-	 * @return String principal email address
-	 */
-	public function getEmail() {
-		return $this->email;
-	}
+    /**
+     * Return whether the group has a credit card
+     * @return string user entered a cc or not
+     */
+    public function hasCreditCard()
+    {
+        return $this->hasCreditCard;
+    }
 
-	/**
-	 * Return whether the group has a credit card
-	 * @return
-	 */
-	public function hasCreditCard() {
-		return $this->hasCreditCard;
-	}
+    /**
+     * Return when the group free trial is finishing
+     * @return DateTime end of free trial
+     */
+    public function getFreeTrialEndAt()
+    {
+        return $this->freeTrialEndAt;
+    }
 
-	/**
-	 * Return when the group free trial is finishing
-	 * @return DateTime end of free trial
-	 */
-	public function getFreeTrialEndAt() {
-		return $this->freeTrialEndAt;
-	}
+    /**
+     * Return the original company name for this group (can be empty)
+     * @return string company name
+     */
+    public function getCompanyName()
+    {
+        return $this->companyName;
+    }
 
-	/**
-	 * Return the original company name for this group
-	 * Can be empty
-	 * @return String company name
-	 */
-	public function getCompanyName() {
-		return $this->companyName;
-	}
+    /**
+     * Return the currency code of main currency used by this group
+     * @return string currency code
+     */
+    public function getCurrency()
+    {
+        return $this->currency;
+    }
 
-	/**
-	 * Return the currency code of main currency used by this group
-	 * @return String currency code
-	 */
-	public function getCurrency() {
-		return $this->currency;
-	}
+    /**
+     * Return the timezone for this group
+     * @return TimeZone group timezone
+     */
+    public function getTimezone()
+    {
+        return $this->timezone;
+    }
 
-	/**
-	 * Return the timezone for this group
-	 * @return TimeZone group timezone
-	 */
-	public function getTimezone() {
-		return $this->timezone;
-	}
+    /**
+     * Return the ALPHA2 country code for this group
+     * @return string alpha2 country code
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
 
-	/**
-	 * Return the ALPHA2 country code for this group
-	 * @return String alpha2 country code
-	 */
-	public function getCountry() {
-		return $this->country;
-	}
+    /**
+     * Return the city in which this group is located
+     * @return string group city
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
 
-	/**
-	 * Return the city in which this group is located
-	 * @return String group city
-	 */
-	public function getCity() {
-		return $this->city;
-	}
-
-	/**
-	 * Return the main accounting package used by this
-	 * group
-	 * @return String group city
-	 */
-	public function getMainAccounting() {
-		return $this->mainAccounting;
-	}
+    /**
+     * Return the main accounting package used by this
+     * group
+     * @return string accounting package
+     */
+    public function getMainAccounting()
+    {
+        return $this->mainAccounting;
+    }
 
 }

--- a/lib/Sso/Service.php
+++ b/lib/Sso/Service.php
@@ -5,179 +5,150 @@
  */
 class Maestrano_Sso_Service extends Maestrano_Util_PresetObject
 {
-  /* Singleton instance */
-  protected static $_instances = array();
+    /* Singleton instance */
+    protected static $_instances = array();
 
-  /* Path to redirect to after signin */
-  protected $after_sso_sign_in_path = '/';
-
-  /* Pointer to the current client session */
-  protected $client_session;
-
-  /**
-   * Returns an instance of this class
-   * (this class uses the singleton pattern)
-   *
-   * @return Maestrano_Sso_Service
-   */
-  public static function instanceWithPreset($preset) {
-      if (!array_key_exists($preset, self::$_instances) || is_null(self::$_instances[$preset])) {
-          self::$_instances[$preset] = new self($preset);
-      }
-      return self::$_instances[$preset];
-  }
-
-  public function __construct($preset)
-  {
-    $this->_preset = $preset;
-  }
-
-  /**
-   * Check if Maestrano SSO is enabled
-   *
-   * @return boolean
-   */
-   public function isSsoEnabled() {
-     return Maestrano::with($this->_preset)->param('sso.enabled');
-   }
-
-   /**
-    * Check if Maestrano SLO is enabled
-    *
-    * @return boolean
-    */
-    public function isSloEnabled() {
-      return Maestrano::with($this->_preset)->param('sso.slo_enabled');
+    /**
+     * Returns an instance of this class for a preset
+     * (this class uses the singleton pattern)
+     *
+     * @param $preset string Marketplace to use
+     * @return Maestrano_Sso_Service
+     */
+    public static function instanceWithPreset($preset) {
+        if (!array_key_exists($preset, self::$_instances) || is_null(self::$_instances[$preset])) {
+            self::$_instances[$preset] = new self($preset);
+        }
+        return self::$_instances[$preset];
     }
 
-  /**
-   * Return the app used to initiate
-   * SSO request
-   *
-   * @return boolean
-   */
-  public function getInitPath() {
-    return Maestrano::with($this->_preset)->param('sso.init_path');
-  }
+    /**
+     * Maestrano_Sso_Service constructor.
+     * @param $preset string
+     */
+    public function __construct($preset)
+    {
+        $this->_preset = $preset;
+    }
 
-  /**
-   * Return where the app should redirect internally to initiate
-   * SSO request
-   *
-   * @return boolean
-   */
-  public function getInitUrl() {
-    $host = Maestrano::with($this->_preset)->param('app.host');
-    $path = $this->getInitPath();
-    return "${host}${path}";
-  }
+    /**
+     * Return the path used to initiate SSO request
+     *
+     * @return string Init path
+     */
+    public function getInitPath() {
+        return Maestrano::with($this->_preset)->param('sso.init_path');
+    }
 
-  /**
-   * The path where the SSO response will be posted and consumed.
-   *
-   * @return string
-   */
-  public function getConsumePath() {
-    return Maestrano::with($this->_preset)->param('sso.consume_path');
-  }
+    /**
+     * Return where the app should redirect internally to initiate SSO request
+     *
+     * @return string Init Url
+     */
+    public function getInitUrl() {
+        $host = Maestrano::with($this->_preset)->param('app.host');
+        $path = $this->getInitPath();
+        return "${host}${path}";
+    }
 
-  /**
-   * The URL where the SSO response will be posted and consumed.
-   *
-   * @return string
-   */
-  public function getConsumeUrl() {
-    $host = Maestrano::with($this->_preset)->param('app.host');
-    $path = $this->getConsumePath();
-    return "${host}${path}";
-  }
+    /**
+     * The path where the SSO response will be posted and consumed.
+     *
+     * @return string
+     */
+    public function getConsumePath() {
+        return Maestrano::with($this->_preset)->param('sso.consume_path');
+    }
 
-  /**
-   * @deprecated Use getLogoutUrlWithUserUid($userUid) instead
-   * Return where the app should redirect after logging user out
-   *
-   * @return string url
-   */
-  public function getLogoutUrl() {
-    $host = Maestrano::with($this->_preset)->param('sso.idp');
-    $endpoint = '/app_logout';
+    /**
+     * The URL where the SSO response will be posted and consumed.
+     *
+     * @return string
+     */
+    public function getConsumeUrl() {
+        $host = Maestrano::with($this->_preset)->param('app.host');
+        $path = $this->getConsumePath();
+        return "${host}${path}";
+    }
 
-    return "${host}${endpoint}";
-  }
+    /**
+     * The URL the user should be redirected after app logged user out
+     *
+     * @param $userUid User UID to logout
+     * @return string url
+     */
+    public function getLogoutUrl($userUid) {
+        $host = Maestrano::with($this->_preset)->param('sso.idp');
+        $endpoint = '/app_logout';
 
-  /**
+        return "${host}${endpoint}?user_uid=${userUid}";
+    }
 
-   * Return where the app should redirect after logging user out
-   *
-   * @return string url
-   */
-  public function getLogoutUrlWithUserUid($userUid) {
-    $host = Maestrano::with($this->_preset)->param('sso.idp');
-    $endpoint = '/app_logout';
+    /**
+     * Return where the app should redirect if user does
+     * not have access to it
+     *
+     * @return string url
+     */
+    public function getUnauthorizedUrl() {
+        $host = Maestrano::with($this->_preset)->param('api.host');
+        $endpoint = '/app_access_unauthorized';
 
-    return "${host}${endpoint}?user_uid=${userUid}";
-  }
+        return "${host}${endpoint}";
+    }
 
-  /**
-   * Return where the app should redirect if user does
-   * not have access to it
-   *
-   * @return string url
-   */
-  public function getUnauthorizedUrl() {
-    $host = Maestrano::with($this->_preset)->param('api.host');
-    $endpoint = '/app_access_unauthorized';
+    /**
+     * Return the host of the marketplace
+     *
+     * @return string url
+     */
+    public function getHost() {
+        return Maestrano::with($this->_preset)->param('api.host');
+    }
 
-    return "${host}${endpoint}";
-  }
+    /**
+     * Maestrano Single Sign-On processing URL
+     *
+     * @return string url
+     */
+    public function getIdpUrl() {
+        $host = Maestrano::with($this->_preset)->param('sso.idp');
+        $api_base = Maestrano::with($this->_preset)->param('api.base');
+        $endpoint = 'auth/saml';
+        return "${host}${api_base}${endpoint}";
+    }
 
-  /**
-   * Return the host of the marketplace
-   *
-   * @return string url
-   */
-  public function getHost() {
-    return Maestrano::with($this->_preset)->param('api.host');
-  }
+    /**
+     * The Maestrano endpoint in charge of providing session information
+     *
+     * @param $user_id string Current user id
+     * @param $sso_session string SSO session
+     * @return string url
+     */
+    public function getSessionCheckUrl($user_id, $sso_session)  {
+        $host = Maestrano::with($this->_preset)->param('sso.idp');
+        $api_base = Maestrano::with($this->_preset)->param('api.base');
+        $endpoint = 'auth/saml';
 
-  /**
-   * Maestrano Single Sign-On processing URL
-   * @var string
-   */
-  public function getIdpUrl() {
-    $host = Maestrano::with($this->_preset)->param('sso.idp');
-    $api_base = Maestrano::with($this->_preset)->param('api.base');
-    $endpoint = 'auth/saml';
-    return "${host}${api_base}${endpoint}";
-  }
+        return "${host}${api_base}${endpoint}/${user_id}?session=${sso_session}";
+    }
 
-  /**
-   * The Maestrano endpoint in charge of providing session information
-   * @var string
-   */
-  public function getSessionCheckUrl($user_id,$sso_session)  {
-    $host = Maestrano::with($this->_preset)->param('sso.idp');
-    $api_base = Maestrano::with($this->_preset)->param('api.base');
-    $endpoint = 'auth/saml';
+    /**
+     * Return a settings object for php-saml
+     *
+     * @return Maestrano_Saml_Settings SAML settings
+     */
+    public function getSamlSettings() {
+        $settings = new Maestrano_Saml_Settings();
 
-    return "${host}${api_base}${endpoint}/${user_id}?session=${sso_session}";
-  }
+        // Configure SAML
+        $settings->idpPublicCertificate = Maestrano::with($this->_preset)->param('sso.x509_certificate');
+        $settings->spIssuer = Maestrano::with($this->_preset)->param('api.id');
+        // TODO: default value?
+        // $settings->requestedNameIdFormat = Maestrano::with($this->_preset)->param('sso.name_id_format');
+        $settings->idpSingleSignOnUrl = $this->getIdpUrl();
+        $settings->spReturnUrl = $this->getConsumeUrl();
 
-  /**
-   * Return a settings object for php-saml
-   *
-   * @return Maestrano_Saml_Settings
-   */
-  public function getSamlSettings() {
-    $settings = new Maestrano_Saml_Settings();
-
-    // Configure SAML
-    $settings->idpPublicCertificate = Maestrano::with($this->_preset)->param('sso.x509_certificate');
-    $settings->spIssuer = Maestrano::with($this->_preset)->param('api.id');
-    $settings->requestedNameIdFormat = Maestrano::with($this->_preset)->param('sso.name_id_format');
-    $settings->idpSingleSignOnUrl = $this->getIdpUrl();
-    $settings->spReturnUrl = $this->getConsumeUrl();
-
-    return $settings;
-  }
+        return $settings;
+    }
 }

--- a/lib/Sso/Service.php
+++ b/lib/Sso/Service.php
@@ -85,19 +85,6 @@ class Maestrano_Sso_Service extends Maestrano_Util_PresetObject
     }
 
     /**
-     * Return where the app should redirect if user does
-     * not have access to it
-     *
-     * @return string url
-     */
-    public function getUnauthorizedUrl() {
-        $host = Maestrano::with($this->_preset)->param('api.host');
-        $endpoint = '/app_access_unauthorized';
-
-        return "${host}${endpoint}";
-    }
-
-    /**
      * Return the host of the marketplace
      *
      * @return string url

--- a/lib/Sso/Session.php
+++ b/lib/Sso/Session.php
@@ -15,7 +15,7 @@ class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
     /**
      * Construct the Maestrano_Sso_Session object
      */
-    public function __construct(&$http_session, $user = null)
+    private function __construct(&$http_session, $user = null)
     {
         // Populate attributes from params
         $this->httpSession = &$http_session;

--- a/lib/Sso/Session.php
+++ b/lib/Sso/Session.php
@@ -13,10 +13,17 @@ class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
     private $recheck = null;
 
     /**
-     * Construct the Maestrano_Sso_Session object
+     * Construct the Maestrano_Sso_Session object, creating a new session
+     *
+     * @param $preset string Marketplace associated to this session
+     * @param $http_session array HTTP Session
+     * @param $user Maestrano_Sso_User
      */
-    private function __construct(&$http_session, $user = null)
+    public function __construct($preset, &$http_session, $user = null)
     {
+        // Save preset to use
+        $this->_preset = $preset;
+
         // Populate attributes from params
         $this->httpSession = &$http_session;
 
@@ -41,21 +48,6 @@ class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
                 $this->recheck = new DateTime($sessionObj['session_recheck']);
             }
         }
-    }
-
-    /**
-     * Create a new session
-     *
-     * @param $preset string Marketplace to log in
-     * @param $http_session array HTTP Session
-     * @param $user Maestrano_Sso_User
-     * @return Maestrano_Sso_Session Session created
-     */
-    public static function create($preset, &$http_session, $user = null)
-    {
-        $obj = new Maestrano_Sso_Session($http_session, $user, $preset);
-        $obj->_preset = $preset;
-        return $obj;
     }
 
     /**

--- a/lib/Sso/Session.php
+++ b/lib/Sso/Session.php
@@ -6,98 +6,98 @@
  */
 class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
 {
-  private $httpSession = null;
-  private $uid = '';
-  private $groupUid = '';
-  private $sessionToken = '';
-  private $recheck = null;
-  protected $preset;
+    private $httpSession = null;
+    private $uid = '';
+    private $groupUid = '';
+    private $sessionToken = '';
+    private $recheck = null;
 
-  /**
-   * Construct the Maestrano_Sso_Session object
-   */
-  public function __construct(&$http_session, $user = null)
-  {
-    // Populate attributes from params
-    $this->httpSession = &$http_session;
+    /**
+     * Construct the Maestrano_Sso_Session object
+     */
+    public function __construct(&$http_session, $user = null)
+    {
+        // Populate attributes from params
+        $this->httpSession = &$http_session;
 
-    if ($user != null) {
-      // Setup the session with $user
-      $this->uid = $user->getUid();
-      $this->groupUid = $user->getGroupUid();
-      $this->sessionToken = $user->getSsoSession();
-      $this->recheck = $user->getSsoSessionRecheck();
-    } else if ($this->ssoTokenExists()) {
-      // Get maestrano sso token
-      $mnoEntry = $this->httpSession['maestrano'];
+        if ($user != null) {
+            // Setup the session with $user
+            $this->uid = $user->getUid();
+            $this->groupUid = $user->getGroupUid();
+            $this->sessionToken = $user->getSsoSession();
+            $this->recheck = $user->getSsoSessionRecheck();
+        } else if ($this->ssoTokenExists()) {
+            // Get maestrano sso token
+            $mnoEntry = $this->httpSession['maestrano'];
 
-      if ($mnoEntry != null) {
-        // Decode the object
-        $sessionObj = base64_decode($mnoEntry);
-        $sessionObj = json_decode($sessionObj, true);
+            if ($mnoEntry != null) {
+                // Decode the object
+                $sessionObj = json_decode(base64_decode($mnoEntry), true);
 
-        // Setup the session
-        $this->uid = $sessionObj['uid'];
-        $this->groupUid = $sessionObj["group_uid"];
-        $this->sessionToken = $sessionObj['session'];
-        $this->recheck = new DateTime($sessionObj['session_recheck']);
-      }
-    }
-  }
-
-  /**
-   * @param string $id The ID of the bill to instantiate.
-   * @param string|null $apiToken
-   *
-   * @return Maestrano_Billing_Bill
-   */
-  public static function newWithPreset($preset, $http_session, $user = null)
-  {
-    $obj = new Maestrano_Sso_Session($http_session, $user, $preset);
-    $obj->_preset = $preset;
-    return $obj;
-  }
-
-  /**
-   * Check if the maestrano SSO token exists in the http session
-   *
-   * @return boolean
-   */
-  public function ssoTokenExists() {
-    if ($this->httpSession != null && array_key_exists('maestrano', $this->httpSession)) {
-      return true;
+                // Setup the session
+                $this->uid = $sessionObj['uid'];
+                $this->groupUid = $sessionObj["group_uid"];
+                $this->sessionToken = $sessionObj['session'];
+                $this->recheck = new DateTime($sessionObj['session_recheck']);
+            }
+        }
     }
 
-    return false;
-  }
+    /**
+     * Create a new session
+     *
+     * @param $preset string Marketplace to log in
+     * @param $http_session array HTTP Session
+     * @param $user Maestrano_Sso_User
+     * @return Maestrano_Sso_Session Session created
+     */
+    public static function create($preset, &$http_session, $user = null)
+    {
+        $obj = new Maestrano_Sso_Session($http_session, $user, $preset);
+        $obj->_preset = $preset;
+        return $obj;
+    }
 
-  /**
-   * Check whether we need to remotely check the
-   * session or not
-   *
-   * @return boolean
-   */
-   public function isRemoteCheckRequired()
-   {
-     if ($this->uid && $this->sessionToken && $this->recheck) {
-       if($this->recheck > (new DateTime('NOW'))) {
-         return false;
-       }
-     }
+    /**
+     * Check if the maestrano SSO token exists in the http session
+     *
+     * @return boolean
+     */
+    public function ssoTokenExists() {
+        if ($this->httpSession != null && array_key_exists('maestrano', $this->httpSession)) {
+            return true;
+        }
 
-     return true;
-   }
+        return false;
+    }
 
-   /**
-    * Return the full url from which session check
-    * should be performed
-    *
-    * @return string the endpoint url
-    */
+    /**
+     * Check whether we need to remotely check the
+     * session or not
+     *
+     * @return boolean
+     */
+    public function isRemoteCheckRequired()
+    {
+        if ($this->uid && $this->sessionToken && $this->recheck) {
+            if($this->recheck > (new DateTime('NOW'))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Return the full url from which session check
+     * should be performed
+     *
+     * @return string the endpoint url
+     */
     public function getSessionCheckUrl()
     {
-      $url = Maestrano::with($this->_preset)->sso()->getSessionCheckUrl($this->uid, $this->sessionToken);
-      return $url;
+        $url = Maestrano::with($this->_preset)->sso()->getSessionCheckUrl($this->uid, $this->sessionToken);
+        return $url;
     }
 
     /**
@@ -107,11 +107,11 @@ class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
      * @return string page content
      */
     public function fetchUrl($url, $httpClient = null) {
-      if ($httpClient == null) {
-        $httpClient = new Maestrano_Net_HttpClient();
-      }
+        if ($httpClient == null) {
+            $httpClient = new Maestrano_Net_HttpClient();
+        }
 
-      return $httpClient->get($url);
+        return $httpClient->get($url);
     }
 
     /**
@@ -120,19 +120,19 @@ class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
      * @return boolean the validity of the session
      */
     public function performRemoteCheck($httpClient = null) {
-      if(empty($this->sessionToken)) { return false; }
-      
-      $json = $this->fetchUrl($this->getSessionCheckUrl(), $httpClient);
-      if ($json) {
-        $response = json_decode($json,true);
+        if(empty($this->sessionToken)) { return false; }
 
-        if ($response['valid'] == "true" && $response['recheck'] != null) {
-          $this->recheck = new DateTime($response['recheck']);
-          return true;
+        $json = $this->fetchUrl($this->getSessionCheckUrl(), $httpClient);
+        if ($json) {
+            $response = json_decode($json,true);
+
+            if ($response['valid'] == "true" && $response['recheck'] != null) {
+                $this->recheck = new DateTime($response['recheck']);
+                return true;
+            }
         }
-      }
 
-      return false;
+        return false;
     }
 
     /**
@@ -140,87 +140,84 @@ class Maestrano_Sso_Session extends Maestrano_Util_PresetObject
      */
     public function getLogoutUrl()
     {
-      return Maestrano::with($this->_preset)->sso()->getLogoutUrlWithUserUid($this->uid);
+        return Maestrano::with($this->_preset)->sso()->getLogoutUrl($this->uid);
     }
 
-  /**
-  * Perform check to see if session is valid
-  * Check is only performed if current time is after
-  * the recheck timestamp
-  * If a remote check is performed then the mno_session_recheck
-  * timestamp is updated in session.
-  *
-  * @return boolean the validity of the session
-  */
-  public function isValid($ifSession = false, $httpClient = null) {
-    if ($ifSession) { return true; }
-    
-    $svc = Maestrano::with($this->_preset)->sso();
-    if (!$svc->isSloEnabled()) return true;
+    /**
+     * Perform check to see if session is valid
+     * Check is only performed if current time is after the recheck timestamp
+     * If a remote check is performed then the mno_session_recheck timestamp is updated in session.
+     *
+     * @param bool $ifSession
+     * @param null $httpClient
+     * @return bool the validity of the session
+     */
+    public function isValid($ifSession = false, $httpClient = null) {
+        if ($ifSession) { return true; }
 
-    if (!$this->ssoTokenExists() || $this->isRemoteCheckRequired()) {
-      if ($this->performRemoteCheck($httpClient)) {
-        $this->save();
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return true;
+        if (!$this->ssoTokenExists() || $this->isRemoteCheckRequired()) {
+            if ($this->performRemoteCheck($httpClient)) {
+                $this->save();
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
     }
-  }
 
-  public function save() {
-    // Set values
-    $sessObj = array();
-    $sessObj['uid'] = $this->uid;
-    $sessObj['group_uid'] = $this->groupUid;
-    $sessObj['session'] = $this->sessionToken;
-    $sessObj['session_recheck'] = $this->recheck->format(DateTime::ISO8601);
+    public function save() {
+        // Set values
+        $sessObj = array();
+        $sessObj['uid'] = $this->uid;
+        $sessObj['group_uid'] = $this->groupUid;
+        $sessObj['session'] = $this->sessionToken;
+        $sessObj['session_recheck'] = $this->recheck->format(DateTime::ISO8601);
 
-    $sessionStr = json_encode($sessObj);
-    $sessionStr = base64_encode($sessionStr);
+        $sessionStr = json_encode($sessObj);
+        $sessionStr = base64_encode($sessionStr);
 
-    $this->httpSession['maestrano'] = $sessionStr;
-  }
+        $this->httpSession['maestrano'] = $sessionStr;
+    }
 
-  public function getUid() {
-    return $this->uid;
-  }
+    public function getUid() {
+        return $this->uid;
+    }
 
-  public function getGroupUid() {
-    return $this->groupUid;
-  }
+    public function getGroupUid() {
+        return $this->groupUid;
+    }
 
-  public function getRecheck() {
-    return $this->recheck;
-  }
+    public function getRecheck() {
+        return $this->recheck;
+    }
 
-  public function getSessionToken() {
-    return $this->sessionToken;
-  }
+    public function getSessionToken() {
+        return $this->sessionToken;
+    }
 
-  public function getHttpSession() {
-    return $this->httpSession;
-  }
+    public function getHttpSession() {
+        return $this->httpSession;
+    }
 
-  public function setUid($uid) {
-    $this->uid = $this->uid;
-  }
+    public function setUid($uid) {
+        $this->uid = $uid;
+    }
 
-  public function setGroupUid($groupUid) {
-    $this->groupUid = $groupUid;
-  }
+    public function setGroupUid($groupUid) {
+        $this->groupUid = $groupUid;
+    }
 
-  public function setRecheck($recheck) {
-    $this->recheck = $recheck;
-  }
+    public function setRecheck($recheck) {
+        $this->recheck = $recheck;
+    }
 
-  public function setSessionToken($sessionToken) {
-    $this->sessionToken = $sessionToken;
-  }
+    public function setSessionToken($sessionToken) {
+        $this->sessionToken = $sessionToken;
+    }
 
-  public function setHttpSession($httpSession) {
-    $this->httpSession = $httpSession;
-  }
+    public function setHttpSession($httpSession) {
+        $this->httpSession = $httpSession;
+    }
 }

--- a/lib/Sso/User.php
+++ b/lib/Sso/User.php
@@ -1,224 +1,187 @@
 <?php
 
 /**
- * Properly format a User received from Maestrano 
- * SAML IDP
+ * Properly format a User received from Maestrano SAML IDP
  */
 class Maestrano_Sso_User
 {
-  /* UID of current group */
-  public $groupUid = '';
-  
-  /* Role in current group */
-  public $groupRole = '';
-  
-  /* User UID */
-  public $uid = '';
-  
-  /* User Virtual UID - unique across users and groups */
-  public $virtualUid = '';
-  
-  /* User email */
-  public $email = '';
-  
-  /* User virtual email - unique across users and groups */
-  public $virtualEmail = '';
-  
-  /* User firstName */
-  public $firstName = '';
-  
-  /* User lastName */
-  public $lastName = '';
-  
-  /* User country - alpha2 code */
-  public $country = '';
-  
-  /* User company firstName */
-  public $companyName = '';
-  
-  /* Maestrano specific user sso session token */
-  public $ssoSession = '';
-  
-  /* When to recheck for validity of the sso session */
-  public $ssoSessionRecheck = null;
-  
-  
-  /**
-   * Construct the Maestrano_Sso_User object from a SAML response
-   *
-   * @param Maestrano_Saml_Response $saml_response
-   *   A SamlResponse object from Maestrano containing details
-   *   about the user being authenticated
-   */
-  public function __construct($saml_response)
-  {
-      // Get assertion attributes
-      $att = $saml_response->getAttributes();
-      
-      // Group related information
-      $this->groupUid  = $att['group_uid'];
-      $this->groupRole = $att['group_role'];
-      
-      // Extract mno session information
-      $this->ssoSession = $att['mno_session'];
-      $this->ssoSessionRecheck = new DateTime($att['mno_session_recheck']);
-      
-      // Extract user metadata
-      $this->uid = $att['uid'];
-      $this->virtualUid = $att['virtual_uid'];
-      $this->email = $att['email'];
-      $this->virtualEmail = $att['virtual_email'];
-      $this->firstName = $att['name'];
-      $this->lastName = $att['surname'];
-      $this->country = $att['country'];
-      $this->companyName = $att['company_name'];
-  }
-  
-  public function toId() {
-    return $this->toUid();
-  }
-  
-	/**
-	 * Return the real UID if Maestrano Sso Creation Mode is set
-   * to "real" and the Virtual UID otherwise ("virtual" mode)
-	 * @return $this->String uid to use in application
-	 */
-    public function toUid()
-    {
-    	if (Maestrano::param('sso.creation_mode') == "real") {
-    		return $this->uid;
-    	} else {
-    		return $this->virtualUid;
-    	}
-    }
-    
+    /* UID of current group */
+    public $groupUid = '';
+
+    /* Role in current group */
+    public $groupRole = '';
+
+    /* User UID */
+    public $uid = '';
+
+    /* User Virtual UID - unique across users and groups */
+    public $virtualUid = '';
+
+    /* User email */
+    public $email = '';
+
+    /* User virtual email - unique across users and groups */
+    public $virtualEmail = '';
+
+    /* User firstName */
+    public $firstName = '';
+
+    /* User lastName */
+    public $lastName = '';
+
+    /* User country - alpha2 code */
+    public $country = '';
+
+    /* User company firstName */
+    public $companyName = '';
+
+    /* Maestrano specific user sso session token */
+    public $ssoSession = '';
+
+    /* When to recheck for validity of the sso session */
+    public $ssoSessionRecheck = null;
+
     /**
-     * Return the real email if Maestrano Sso Creation Mode is set
-     * to "real" and the Virtual email otherwise ("virtual" mode)
-     * @return
+     * Construct the Maestrano_Sso_User object from a SAML response
+     * @param $saml_response Maestrano_Saml_Response A SamlResponse object from Maestrano
      */
-    public function toEmail()
+    public function __construct($saml_response)
     {
-    	if (Maestrano::param('sso.creation_mode') == "real") {
-    		return $this->email;
-    	} else {
-    		return $this->virtualEmail;
-    	}
+        // Get assertion attributes
+        $att = $saml_response->getAttributes();
+
+        // Group related information
+        $this->groupUid = $att['group_uid'];
+        $this->groupRole = $att['group_role'];
+
+        // Extract mno session information
+        $this->ssoSession = $att['mno_session'];
+        $this->ssoSessionRecheck = new DateTime($att['mno_session_recheck']);
+
+        // Extract user metadata
+        $this->uid = $att['uid'];
+        $this->virtualUid = $att['virtual_uid'];
+        $this->virtualEmail = $att['virtual_email'];
+        $this->email = $att['email'];
+        $this->firstName = $att['name'];
+        $this->lastName = $att['surname'];
+        $this->country = $att['country'];
+        $this->companyName = $att['company_name'];
     }
-	
-	/**
-	 * Return the current user session token
-	 * @return String session token
-	 */
-	public function getSsoSession() {
-		return $this->ssoSession;
-	}
-	
-	/**
-	 * Return when the user session should be remotely checked
-	 * @return DateTime session check time
-	 */
-	public function getSsoSessionRecheck() {
-		return $this->ssoSessionRecheck;
-	}
-	
-	/**
-	 * Return the user group UID 
-	 * @return String group UID
-	 */
-	public function getGroupUid() {
-		return $this->groupUid;
-	}
-	
-	/**
-	 * Return the user role in the group
-	 * Roles are: 'Member', 'Power User', 'Admin', 'Super Admin'
-	 * @return String user role in group
-	 */
-	public function getGroupRole() {
-		return $this->groupRole;
-	}
-	
-	/**
-	 * The Maestrano user ID (UID)
-	 * @return String user ID (UID)
-	 */
-	public function getId() {
-		return $this->uid;
-	}
-  
-	/**
-	 * The Maestrano user UID
-	 * @return String user UID
-	 */
-	public function getUid() {
-		return $this->uid;
-	}
-	
-	/**
-	 * The user virtual (ID) UID which is truly unique across users and groups
-	 * @return String user virtual uid
-	 */
-	public function getVirtualId() {
-		return $this->virtualUid;
-	}
-  
-	/**
-	 * The user virtual UID which is truly unique across users and groups
-	 * @return String user virtual uid
-	 */
-	public function getVirtualUid() {
-		return $this->virtualUid;
-	}
-	
-	/**
-	 * The actual user email 
-	 * @return String user email
-	 */
-	public function getEmail() {
-		return $this->email;
-	}
-	
-	/**
-	 * Virtual email that can be used instead of regular email fields
-	 * This email is unique across users and groups
-	 * Do not use this email address to send emails to the user
-	 * @return String virtual email
-	 */
-	public function getVirtualEmail() {
-		return $this->virtualEmail;
-	}
-	
-	/**
-	 * User first firstName
-	 * @return String user first name
-	 */
-	public function getFirstName() {
-		return $this->firstName;
-	}
-	
-	/**
-	 * User last last name
-	 * @return String user last name
-	 */
-	public function getLastName() {
-		return $this->lastName;
-	}
-	
-	/**
-	 * ALPHA2 code of user country
-	 * @return
-	 */
-	public function getCountry() {
-		return $this->country;
-	}
-	
-	/**
-	 * Company firstName entered by the user
-	 * Can be empty
-	 * @return String company name
-	 */
-	public function getCompanyName() {
-		return $this->companyName;
-	}
+
+    /**
+     * The Maestrano user ID (UID)
+     * @return string user ID (UID)
+     */
+    public function getId() {
+        return $this->uid;
+    }
+
+    /**
+     * The Maestrano user UID
+     * @return string user UID
+     */
+    public function getUid() {
+        return $this->uid;
+    }
+
+    /**
+     * The user virtual (ID) UID which is truly unique across users and groups
+     * @return string user virtual uid
+     */
+    public function getVirtualId() {
+        return $this->virtualUid;
+    }
+
+    /**
+     * The user virtual UID which is truly unique across users and groups
+     * @return string user virtual uid
+     */
+    public function getVirtualUid() {
+        return $this->virtualUid;
+    }
+
+    /**
+     * The actual user email
+     * @return string user email
+     */
+    public function getEmail() {
+        return $this->email;
+    }
+
+    /**
+     * Virtual email that can be used instead of regular email fields
+     * This email is unique across users and groups
+     * Do not use this email address to send emails to the user
+     * @return string virtual email
+     */
+    public function getVirtualEmail() {
+        return $this->virtualEmail;
+    }
+
+    /**
+     * Return the current user session token
+     * @return string session token
+     */
+    public function getSsoSession() {
+        return $this->ssoSession;
+    }
+
+    /**
+     * Return when the user session should be remotely checked
+     * @return DateTime session check time
+     */
+    public function getSsoSessionRecheck() {
+        return $this->ssoSessionRecheck;
+    }
+
+    /**
+     * Return the user group UID
+     * @return string group UID
+     */
+    public function getGroupUid() {
+        return $this->groupUid;
+    }
+
+    /**
+     * Return the user role in the group
+     * Roles are: 'Member', 'Power User', 'Admin', 'Super Admin'
+     * @return string user role in group
+     */
+    public function getGroupRole() {
+        return $this->groupRole;
+    }
+
+    /**
+     * User first firstName
+     * @return string user first name
+     */
+    public function getFirstName() {
+        return $this->firstName;
+    }
+
+    /**
+     * User last last name
+     * @return string user last name
+     */
+    public function getLastName() {
+        return $this->lastName;
+    }
+
+    /**
+     * ALPHA2 code of user country
+     * @return string country
+     */
+    public function getCountry() {
+        return $this->country;
+    }
+
+    /**
+     * Company firstName entered by the user
+     * Can be empty
+     * @return string company name
+     */
+    public function getCompanyName() {
+        return $this->companyName;
+    }
 }

--- a/lib/Util/PresetObject.php
+++ b/lib/Util/PresetObject.php
@@ -2,39 +2,37 @@
 
 class Maestrano_Util_PresetObject
 {
-  /* Internal Config Map */
-  public static $preset_cache = array();
-  protected $_preset;
+    /* Internal Config Map */
+    public static $preset_cache = array();
+    protected $_preset;
 
-  /**
-   * Create a preset proxy
-   * @param $preset String: Name of the preset
-   * @return Maestrano_Util_PresetProxy: a preset proxy
-   */
-  public static function with($preset) {
-    $cname = get_called_class();
-    if (is_null($preset)) {
-      $preset = 'maestrano';
+    /**
+     * Create a preset proxy
+     * @param $preset String: Name of the preset
+     * @return Maestrano_Util_PresetProxy: a preset proxy
+     */
+    public static function with($preset)
+    {
+        $cname = get_called_class();
+
+        if (!array_key_exists($cname, self::$preset_cache) || is_null(self::$preset_cache[$cname])) {
+            self::$preset_cache[$cname] = array();
+        }
+
+        if (!array_key_exists($preset, self::$preset_cache[$cname]) || is_null(self::$preset_cache[$cname][$preset])) {
+            self::$preset_cache[$cname][$preset] = new Maestrano_Util_PresetProxy(get_called_class(), $preset);
+        }
+
+        return self::$preset_cache[$cname][$preset];
     }
 
-    if (!array_key_exists($cname, self::$preset_cache) || is_null(self::$preset_cache[$cname])) {
-      self::$preset_cache[$cname] = array();
+    public static function __callStatic($name, $arguments)
+    {
+        if (method_exists(get_called_class(), $name . 'WithPreset')) {
+            array_unshift($arguments, 'maestrano');
+            return call_user_func_array(get_called_class() . '::' . $name . 'WithPreset', $arguments);
+        } else {
+            throw new BadMethodCallException('Method ' . $name . ' does not exist');
+        }
     }
-
-    if (!array_key_exists($preset, self::$preset_cache[$cname]) || is_null(self::$preset_cache[$cname][$preset])) {
-      self::$preset_cache[$cname][$preset] = new Maestrano_Util_PresetProxy(get_called_class(),$preset);
-    }
-
-    return self::$preset_cache[$cname][$preset];
-  }
-
-  public static function __callStatic($name, $arguments)
-  {
-    if (method_exists(get_called_class(),$name . 'WithPreset')) {
-      array_unshift($arguments,'maestrano');
-      return call_user_func_array(get_called_class() . '::' . $name . 'WithPreset',$arguments);
-    } else {
-      throw new BadMethodCallException('Method ' . $name . ' does not exist');
-    }
-  }
 }

--- a/lib/Util/PresetProxy.php
+++ b/lib/Util/PresetProxy.php
@@ -3,15 +3,15 @@
 class Maestrano_Util_PresetProxy
 {
 
-  public function __construct($class_name, $preset = 'maestrano')
-  {
-    $this->class_name = $class_name;
-    $this->preset = $preset;
-  }
+    public function __construct($class_name, $preset)
+    {
+        $this->class_name = $class_name;
+        $this->preset = $preset;
+    }
 
-  public function __call($name, $arguments)
-  {
-    array_unshift($arguments,$this->preset);
-    return call_user_func_array($this->class_name . '::' . $name . 'WithPreset',$arguments);
-  }
+    public function __call($name, $arguments)
+    {
+        array_unshift($arguments, $this->preset);
+        return call_user_func_array($this->class_name . '::' . $name . 'WithPreset', $arguments);
+    }
 }

--- a/lib/Util/Set.php
+++ b/lib/Util/Set.php
@@ -2,33 +2,33 @@
 
 class Maestrano_Util_Set
 {
-  private $_elts;
+    private $_elts;
 
-  public function __construct($members=array())
-  {
-    $this->_elts = array();
-    foreach ($members as $item)
-      $this->_elts[$item] = true;
-  }
+    public function __construct($members = array())
+    {
+        $this->_elts = array();
+        foreach ($members as $item)
+            $this->_elts[$item] = true;
+    }
 
-  public function includes($elt)
-  {
-    return isset($this->_elts[$elt]);
-  }
+    public function includes($elt)
+    {
+        return isset($this->_elts[$elt]);
+    }
 
-  public function add($elt)
-  {
-    $this->_elts[$elt] = true;
-  }
+    public function add($elt)
+    {
+        $this->_elts[$elt] = true;
+    }
 
-  public function discard($elt)
-  {
-    unset($this->_elts[$elt]);
-  }
+    public function discard($elt)
+    {
+        unset($this->_elts[$elt]);
+    }
 
-  // TODO: make Set support foreach
-  public function toArray()
-  {
-    return array_keys($this->_elts);
-  }
+    // TODO: make Set support foreach
+    public function toArray()
+    {
+        return array_keys($this->_elts);
+    }
 }

--- a/tests/Config/ConfigIntegrationTest.php
+++ b/tests/Config/ConfigIntegrationTest.php
@@ -26,7 +26,6 @@ class ConfigIntegrationTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($result['dev-platform.host'], 'https://dev-platform.maestrano.com');
         $this->assertEquals($result['dev-platform.api_path'], '/api/config/v1/');
-        $this->assertEquals($result['environment.name'], 'local');
         $this->assertEquals($result['environment.api_key'], '5e351c6a-b385-425d-b7d2-bafdb22f9476');
         $this->assertEquals($result['environment.api_secret'], 'SFHrk0XVRZXfQS9hO8stYA');
     }
@@ -40,12 +39,6 @@ class ConfigIntegrationTest extends PHPUnit_Framework_TestCase
     public function testConfigurePathError() {
         unset($this->config['dev-platform']['api_path']);
         $this->setExpectedException('Maestrano_Config_Error', 'Missing \'dev-platform.api_path\' parameter in dev-platform config.');
-        Maestrano_Config_Client::with('dev-platform')->configure($this->config);
-    }
-
-    public function testConfigureEnvironmentNameError() {
-        unset($this->config['environment']['name']);
-        $this->setExpectedException('Maestrano_Config_Error', 'Missing \'environment.name\' parameter in dev-platform config.');
         Maestrano_Config_Client::with('dev-platform')->configure($this->config);
     }
 

--- a/tests/MaestranoTest.php
+++ b/tests/MaestranoTest.php
@@ -2,207 +2,174 @@
 
 class MaestranoTest extends PHPUnit_Framework_TestCase
 {
-    protected $config;
-
     protected function setUp()
     {
-      $this->config = array(
-        'environment' => 'production',
-        'app' => array(
-          'host' => "https://mysuperapp.com",
-        ),
-        'api' => array(
-          'id' => "myappid",
-          'key' => "myappkey",
-          'group_id' => "mygroupid",
-          'host' => 'https://someapihost.com'
-        ),
-        'sso' => array(
-          'init_path' => "/mno/init_path.php",
-          'consume_path' => "/mno/consume_path.php",
-          'idp' => "https://mysuperidp.com",
-          'idm' => "https://mysuperidm.com",
-          'x509_fingerprint' => "some-x509_fingerprint",
-          'x509_certificate' => "some-x509_certificate"
-        ),
-        'connec' => array(
-          'enabled' => true,
-          'host' => 'http://connec.maestrano.io',
-          'base_path' => '/api',
-          'v2_path' => '/v2',
-          'reports_path' => '/reports'
-        ),
-        'webhook' => array(
-          'account' => array(
-            'groups_path' => "/mno/groups/:id",
-            'group_users_path' => "/mno/groups/:group_id/users/:id"
-          ),
-          'connec' => array(
-            'enabled' => true,
-            'initialization_path' => "/mno/connec/initialization",
-            'notifications_path' => "/mno/connec/notifications",
-            'subscriptions' => array(
-              'organizations' => true,
-              'people' => true
+        $this->config = MaestranoTestHelper::getConfig();
+    }
+
+    public function testConfigurationBinding()
+    {
+        $marketplace = 'same-marketplace';
+        Maestrano::with($marketplace)->configure($this->config['marketplaces'][0]);
+
+        $this->assertEquals($this->config['marketplaces'][0]['nid'], Maestrano::with($marketplace)->param('nid'));
+        $this->assertEquals($this->config['marketplaces'][0]['marketplace'], Maestrano::with($marketplace)->param('marketplace'));
+        $this->assertEquals($this->config['marketplaces'][0]['environment'], Maestrano::with($marketplace)->param('environment'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['host'], Maestrano::with($marketplace)->param('app.host'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['synchronization_start_path'], Maestrano::with($marketplace)->param('app.synchronization_start_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['synchronization_toggle_path'], Maestrano::with($marketplace)->param('app.synchronization_toggle_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['synchronization_status_path'], Maestrano::with($marketplace)->param('app.synchronization_status_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['id'], Maestrano::with($marketplace)->param('api.id'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['key'], Maestrano::with($marketplace)->param('api.key'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['host'], Maestrano::with($marketplace)->param('api.host'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['base'], Maestrano::with($marketplace)->param('api.base'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['idm'], Maestrano::with($marketplace)->param('sso.idm'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['init_path'], Maestrano::with($marketplace)->param('sso.init_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['consume_path'], Maestrano::with($marketplace)->param('sso.consume_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['idp'], Maestrano::with($marketplace)->param('sso.idp'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['x509_fingerprint'], Maestrano::with($marketplace)->param('sso.x509_fingerprint'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['x509_certificate'], Maestrano::with($marketplace)->param('sso.x509_certificate'));
+        $this->assertEquals($this->config['marketplaces'][0]['connec']['host'], Maestrano::with($marketplace)->param('connec.host'));
+        $this->assertEquals($this->config['marketplaces'][0]['connec']['base_path'], Maestrano::with($marketplace)->param('connec.base_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['connec']['timeout'], Maestrano::with($marketplace)->param('connec.timeout'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['account']['group_path'], Maestrano::with($marketplace)->param('webhooks.account.group_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['account']['group_user_path'], Maestrano::with($marketplace)->param('webhooks.account.group_user_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['connec']['external_ids'], Maestrano::with($marketplace)->param('webhooks.connec.external_ids'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['connec']['initialization_path'], Maestrano::with($marketplace)->param('webhooks.connec.initialization_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['connec']['notification_path'], Maestrano::with($marketplace)->param('webhooks.connec.notification_path'));
+    }
+
+    public function testConfigurationFromFile()
+    {
+        $this->setExpectedException(Maestrano_Config_Error::class);
+
+        $path = "config.json";
+        file_put_contents($path, json_encode($this->config['marketplaces'][0]));
+
+        Maestrano::configure($path);
+
+        unlink($path);
+    }
+
+    public function testAuthenticateWhenValid()
+    {
+        $preset = 'some-marketplace';
+        Maestrano::with($preset)->configure($this->config['marketplaces'][0]);
+
+        $this->assertTrue(Maestrano::with($preset)->authenticate($this->config['marketplaces'][0]['api']['id'], $this->config['marketplaces'][0]['api']['key']));
+    }
+
+    public function testAuthenticateWhenInvalid()
+    {
+        $preset = 'some-marketplace';
+        Maestrano::with($preset)->configure($this->config['marketplaces'][0]);
+
+        $this->assertFalse(Maestrano::with($preset)->authenticate($this->config['marketplaces'][0]['api']['id'] . "aaa", $this->config['marketplaces'][0]['api']['key']));
+        $this->assertFalse(Maestrano::with($preset)->authenticate($this->config['marketplaces'][0]['api']['id'], $this->config['marketplaces'][0]['api']['key'] . "aaa"));
+    }
+
+    public function testPresetWithNullPreset()
+    {
+        $this->setExpectedException(Maestrano_Config_Error::class, 'Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
+
+        Maestrano::paramWithPreset(null, 'api.key');
+    }
+
+    public function testPresetWithEmptyStringPreset()
+    {
+        $this->setExpectedException(Maestrano_Config_Error::class, 'Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
+
+        Maestrano::paramWithPreset('', 'api.key');
+    }
+
+    public function testPresetNotConfigured()
+    {
+        $this->setExpectedException(Maestrano_Config_Error::class, "Maestrano was not configured for preset 'another-marketplace'");
+
+        Maestrano::with('some-marketplace')->configure($this->config['marketplaces'][0]);
+        Maestrano::paramWithPreset('another-marketplace', 'api.key');
+    }
+
+    public function testBindingConfigurationWithPreset()
+    {
+        $preset = 'some-marketplace';
+        Maestrano::with($preset)->configure($this->config['marketplaces'][0]);
+
+        $this->assertEquals($this->config['marketplaces'][0]['nid'], Maestrano::with($preset)->param('nid'));
+        $this->assertEquals($this->config['marketplaces'][0]['marketplace'], Maestrano::with($preset)->param('marketplace'));
+        $this->assertEquals($this->config['marketplaces'][0]['environment'], Maestrano::with($preset)->param('environment'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['host'], Maestrano::with($preset)->param('app.host'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['synchronization_start_path'], Maestrano::with($preset)->param('app.synchronization_start_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['synchronization_toggle_path'], Maestrano::with($preset)->param('app.synchronization_toggle_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['app']['synchronization_status_path'], Maestrano::with($preset)->param('app.synchronization_status_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['id'], Maestrano::with($preset)->param('api.id'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['key'], Maestrano::with($preset)->param('api.key'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['host'], Maestrano::with($preset)->param('api.host'));
+        $this->assertEquals($this->config['marketplaces'][0]['api']['base'], Maestrano::with($preset)->param('api.base'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['idm'], Maestrano::with($preset)->param('sso.idm'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['init_path'], Maestrano::with($preset)->param('sso.init_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['consume_path'], Maestrano::with($preset)->param('sso.consume_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['idp'], Maestrano::with($preset)->param('sso.idp'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['x509_fingerprint'], Maestrano::with($preset)->param('sso.x509_fingerprint'));
+        $this->assertEquals($this->config['marketplaces'][0]['sso']['x509_certificate'], Maestrano::with($preset)->param('sso.x509_certificate'));
+        $this->assertEquals($this->config['marketplaces'][0]['connec']['host'], Maestrano::with($preset)->param('connec.host'));
+        $this->assertEquals($this->config['marketplaces'][0]['connec']['base_path'], Maestrano::with($preset)->param('connec.base_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['connec']['timeout'], Maestrano::with($preset)->param('connec.timeout'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['account']['group_path'], Maestrano::with($preset)->param('webhooks.account.group_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['account']['group_user_path'], Maestrano::with($preset)->param('webhooks.account.group_user_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['connec']['external_ids'], Maestrano::with($preset)->param('webhooks.connec.external_ids'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['connec']['initialization_path'], Maestrano::with($preset)->param('webhooks.connec.initialization_path'));
+        $this->assertEquals($this->config['marketplaces'][0]['webhooks']['connec']['notification_path'], Maestrano::with($preset)->param('webhooks.connec.notification_path'));
+    }
+
+    public function testToMetadata()
+    {
+        $preset = 'some-marketplace';
+        Maestrano::with($preset)->configure($this->config['marketplaces'][0]);
+
+        $expected = array(
+            'nid' => $this->config['marketplaces'][0]['nid'],
+            'marketplace' => $this->config['marketplaces'][0]['marketplace'],
+            'environment' => $this->config['marketplaces'][0]['environment'],
+            'app' => array(
+                'host' => $this->config['marketplaces'][0]['app']['host'],
+                'synchronization_start_path' => $this->config['marketplaces'][0]['app']['synchronization_start_path'],
+                'synchronization_toggle_path' => $this->config['marketplaces'][0]['app']['synchronization_toggle_path'],
+                'synchronization_status_path' => $this->config['marketplaces'][0]['app']['synchronization_status_path']
+            ),
+            'api' => array(
+                'id' => $this->config['marketplaces'][0]['api']['id'],
+                'key' => $this->config['marketplaces'][0]['api']['key'],
+                'host' => $this->config['marketplaces'][0]['api']['host'],
+                'base' => $this->config['marketplaces'][0]['api']['base'],
+                'version' => Maestrano::VERSION,
+                'lang' => 'php',
+                'lang_version' => phpversion() . " " . php_uname(),
+            ),
+            'sso' => array(
+                'idm' => $this->config['marketplaces'][0]['sso']['idm'],
+                'init_path' => $this->config['marketplaces'][0]['sso']['init_path'],
+                'consume_path' => $this->config['marketplaces'][0]['sso']['consume_path'],
+                'idp' => $this->config['marketplaces'][0]['sso']['idp'],
+            ),
+            'connec' => array(
+                'host' => $this->config['marketplaces'][0]['connec']['host'],
+                'base_path' => $this->config['marketplaces'][0]['connec']['base_path'],
+                'timeout' => $this->config['marketplaces'][0]['connec']['timeout']
+            ),
+            'webhooks' => array(
+                'account' => array(
+                    'group_path' => $this->config['marketplaces'][0]['webhooks']['account']['group_path'],
+                    'group_user_path' => $this->config['marketplaces'][0]['webhooks']['account']['group_user_path'],
+                ),
+                'connec' => array(
+                    'external_ids' => $this->config['marketplaces'][0]['webhooks']['connec']['external_ids'],
+                    'initialization_path' => $this->config['marketplaces'][0]['webhooks']['connec']['initialization_path'],
+                    'notification_path' => $this->config['marketplaces'][0]['webhooks']['connec']['notification_path']
+                )
             )
-          )
-        )
-      );
-    }
+        );
 
-    public function testBindingConfiguration() {
-      Maestrano::configure($this->config);
-
-      $this->assertEquals($this->config['environment'], Maestrano::param('environment'));
-      $this->assertEquals($this->config['app']['host'], Maestrano::param('app.host'));
-      $this->assertEquals($this->config['api']['id'], Maestrano::param('api.id'));
-      $this->assertEquals($this->config['api']['key'], Maestrano::param('api.key'));
-      $this->assertEquals($this->config['api']['host'], Maestrano::param('api.host'));
-      $this->assertEquals($this->config['api']['group_id'], Maestrano::param('api.group_id'));
-      $this->assertEquals($this->config['sso']['init_path'], Maestrano::param('sso.init_path'));
-      $this->assertEquals($this->config['sso']['consume_path'], Maestrano::param('sso.consume_path'));
-      $this->assertEquals($this->config['sso']['idp'], Maestrano::param('sso.idp'));
-      $this->assertEquals($this->config['sso']['x509_fingerprint'], Maestrano::param('sso.x509_fingerprint'));
-      $this->assertEquals($this->config['sso']['x509_certificate'], Maestrano::param('sso.x509_certificate'));
-      $this->assertEquals($this->config['connec']['enabled'], Maestrano::param('connec.enabled'));
-      $this->assertEquals($this->config['connec']['host'], Maestrano::param('connec.host'));
-      $this->assertEquals($this->config['connec']['base_path'], Maestrano::param('connec.base_path'));
-      $this->assertEquals($this->config['connec']['v2_path'], Maestrano::param('connec.v2_path'));
-      $this->assertEquals($this->config['connec']['reports_path'], Maestrano::param('connec.reports_path'));
-      $this->assertEquals($this->config['webhook']['account']['groups_path'], Maestrano::param('webhook.account.groups_path'));
-      $this->assertEquals($this->config['webhook']['account']['group_users_path'], Maestrano::param('webhook.account.group_users_path'));
-      $this->assertEquals($this->config['webhook']['connec']['initialization_path'], Maestrano::param('webhook.connec.initialization_path'));
-      $this->assertEquals($this->config['webhook']['connec']['notifications_path'], Maestrano::param('webhook.connec.notifications_path'));
-      $this->assertEquals($this->config['webhook']['connec']['subscriptions'], Maestrano::param('webhook.connec.subscriptions'));
-    }
-
-    public function testBindingConfigurationBooleanViaJson() {
-      $config = array('environment' => 'production', 'sso' => array('enabled' => false));
-      Maestrano::configure(json_decode(json_encode($config),true));
-
-      $this->assertFalse(Maestrano::param('sso.enabled'));
-    }
-
-    public function testConfigurationFromFile() {
-      $path = "config.json";
-      file_put_contents($path, json_encode($this->config));
-
-      Maestrano::configure($path);
-      $this->assertEquals($this->config['environment'], Maestrano::param('environment'));
-      $this->assertEquals($this->config['app']['host'], Maestrano::param('app.host'));
-      $this->assertEquals($this->config['api']['id'], Maestrano::param('api.id'));
-      $this->assertEquals($this->config['api']['key'], Maestrano::param('api.key'));
-      $this->assertEquals($this->config['api']['host'], Maestrano::param('api.host'));
-      $this->assertEquals($this->config['api']['group_id'], Maestrano::param('api.group_id'));
-      $this->assertEquals($this->config['sso']['init_path'], Maestrano::param('sso.init_path'));
-      $this->assertEquals($this->config['sso']['consume_path'], Maestrano::param('sso.consume_path'));
-      $this->assertEquals($this->config['sso']['idp'], Maestrano::param('sso.idp'));
-      $this->assertEquals($this->config['sso']['x509_fingerprint'], Maestrano::param('sso.x509_fingerprint'));
-      $this->assertEquals($this->config['sso']['x509_certificate'], Maestrano::param('sso.x509_certificate'));
-      $this->assertEquals($this->config['connec']['enabled'], Maestrano::param('connec.enabled'));
-      $this->assertEquals($this->config['connec']['host'], Maestrano::param('connec.host'));
-      $this->assertEquals($this->config['connec']['base_path'], Maestrano::param('connec.base_path'));
-      $this->assertEquals($this->config['connec']['v2_path'], Maestrano::param('connec.v2_path'));
-      $this->assertEquals($this->config['connec']['reports_path'], Maestrano::param('connec.reports_path'));
-      $this->assertEquals($this->config['webhook']['account']['groups_path'], Maestrano::param('webhook.account.groups_path'));
-      $this->assertEquals($this->config['webhook']['account']['group_users_path'], Maestrano::param('webhook.account.group_users_path'));
-      $this->assertEquals($this->config['webhook']['connec']['initialization_path'], Maestrano::param('webhook.connec.initialization_path'));
-      $this->assertEquals($this->config['webhook']['connec']['notifications_path'], Maestrano::param('webhook.connec.notifications_path'));
-      $this->assertEquals($this->config['webhook']['connec']['subscriptions'], Maestrano::param('webhook.connec.subscriptions'));
-
-      unlink($path);
-    }
-
-    public function testAuthenticateWhenValid() {
-      Maestrano::configure($this->config);
-
-      $this->assertTrue(Maestrano::authenticate($this->config['api']['id'],$this->config['api']['key']));
-    }
-
-    public function testAuthenticateWhenInvalid() {
-      Maestrano::configure($this->config);
-
-      $this->assertFalse(Maestrano::authenticate($this->config['api']['id'] . "aaa",$this->config['api']['key']));
-      $this->assertFalse(Maestrano::authenticate($this->config['api']['id'],$this->config['api']['key'] . "aaa"));
-    }
-
-    public function testBindingConfigurationWithPreset() {
-      $preset = 'some-marketplace';
-      Maestrano::with($preset)->configure($this->config);
-
-      $this->assertEquals($this->config['environment'], Maestrano::with($preset)->param('environment'));
-      $this->assertEquals($this->config['app']['host'], Maestrano::with($preset)->param('app.host'));
-      $this->assertEquals($this->config['api']['id'], Maestrano::with($preset)->param('api.id'));
-      $this->assertEquals($this->config['api']['key'], Maestrano::with($preset)->param('api.key'));
-      $this->assertEquals($this->config['api']['group_id'], Maestrano::with($preset)->param('api.group_id'));
-      $this->assertEquals($this->config['api']['host'], Maestrano::with($preset)->param('api.host'));
-      $this->assertEquals($this->config['sso']['init_path'], Maestrano::with($preset)->param('sso.init_path'));
-      $this->assertEquals($this->config['sso']['consume_path'], Maestrano::with($preset)->param('sso.consume_path'));
-      $this->assertEquals($this->config['sso']['idp'], Maestrano::with($preset)->param('sso.idp'));
-      $this->assertEquals($this->config['sso']['x509_fingerprint'], Maestrano::with($preset)->param('sso.x509_fingerprint'));
-      $this->assertEquals($this->config['sso']['x509_certificate'], Maestrano::with($preset)->param('sso.x509_certificate'));
-      $this->assertEquals($this->config['connec']['enabled'], Maestrano::with($preset)->param('connec.enabled'));
-      $this->assertEquals($this->config['connec']['host'], Maestrano::with($preset)->param('connec.host'));
-      $this->assertEquals($this->config['connec']['base_path'], Maestrano::with($preset)->param('connec.base_path'));
-      $this->assertEquals($this->config['connec']['v2_path'], Maestrano::with($preset)->param('connec.v2_path'));
-      $this->assertEquals($this->config['connec']['reports_path'], Maestrano::with($preset)->param('connec.reports_path'));
-      $this->assertEquals($this->config['webhook']['account']['groups_path'], Maestrano::with($preset)->param('webhook.account.groups_path'));
-      $this->assertEquals($this->config['webhook']['account']['group_users_path'], Maestrano::with($preset)->param('webhook.account.group_users_path'));
-      $this->assertEquals($this->config['webhook']['connec']['initialization_path'], Maestrano::with($preset)->param('webhook.connec.initialization_path'));
-      $this->assertEquals($this->config['webhook']['connec']['notifications_path'], Maestrano::with($preset)->param('webhook.connec.notifications_path'));
-      $this->assertEquals($this->config['webhook']['connec']['subscriptions'], Maestrano::with($preset)->param('webhook.connec.subscriptions'));
-    }
-
-    public function testToMetadata() {
-      Maestrano::configure($this->config);
-
-      $expected = array(
-        'environment'        => $this->config['environment'],
-        'app' => array(
-          'host'             => $this->config['app']['host']
-        ),
-        'api' => array(
-          'id'               => $this->config['api']['id'],
-          'version'          => Maestrano::VERSION,
-          'verify_ssl_certs' => false,
-          'lang'             => 'php',
-          'lang_version'     => phpversion() . " " . php_uname(),
-          'host'             => $this->config['api']['host'],
-          'base'             => Maestrano::$EVT_CONFIG[$this->config['environment']]['api.base'],
-        ),
-        'sso' => array(
-          'enabled'          => true,
-          'slo_enabled'      => true,
-          'init_path'        => $this->config['sso']['init_path'],
-          'consume_path'     => $this->config['sso']['consume_path'],
-          'creation_mode'    => 'real',
-          'idm'              => $this->config['sso']['idm'],
-          'idp'              => $this->config['sso']['idp'],
-          'name_id_format'   => Maestrano::$EVT_CONFIG[$this->config['environment']]['sso.name_id_format'],
-          'x509_fingerprint' => $this->config['sso']['x509_fingerprint'],
-          'x509_certificate' => $this->config['sso']['x509_certificate'],
-        ),
-        'connec' => array(
-          'enabled'          => $this->config['connec']['enabled'],
-          'host'             => $this->config['connec']['host'],
-          'base_path'        => $this->config['connec']['base_path'],
-          'v2_path'          => $this->config['connec']['v2_path'],
-          'reports_path'     => $this->config['connec']['reports_path']
-        ),
-        'webhook' => array(
-          'account' => array(
-            'groups_path'      => $this->config['webhook']['account']['groups_path'],
-            'group_users_path' => $this->config['webhook']['account']['group_users_path'],
-          ),
-          'connec' => array(
-            'initialization_path' => $this->config['webhook']['connec']['initialization_path'],
-            'notifications_path'  => $this->config['webhook']['connec']['notifications_path'],
-            'subscriptions'       => $this->config['webhook']['connec']['subscriptions']
-          )
-        )
-      );
-
-      $this->assertEquals(json_encode($expected),Maestrano::toMetadata());
+        $this->assertEquals(json_encode($expected), Maestrano::with($preset)->toMetadata());
     }
 }
-?>

--- a/tests/MaestranoTest.php
+++ b/tests/MaestranoTest.php
@@ -41,7 +41,7 @@ class MaestranoTest extends PHPUnit_Framework_TestCase
 
     public function testConfigurationFromFile()
     {
-        $this->setExpectedException(Maestrano_Config_Error::class);
+        $this->setExpectedException('Maestrano_Config_Error');
 
         $path = "config.json";
         file_put_contents($path, json_encode($this->config['marketplaces'][0]));
@@ -70,21 +70,21 @@ class MaestranoTest extends PHPUnit_Framework_TestCase
 
     public function testPresetWithNullPreset()
     {
-        $this->setExpectedException(Maestrano_Config_Error::class, 'Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
+        $this->setExpectedException('Maestrano_Config_Error', 'Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
 
         Maestrano::paramWithPreset(null, 'api.key');
     }
 
     public function testPresetWithEmptyStringPreset()
     {
-        $this->setExpectedException(Maestrano_Config_Error::class, 'Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
+        $this->setExpectedException('Maestrano_Config_Error', 'Empty preset name, make sure you are using \'Maestrano::with($marketplace)->someMethod()\'');
 
         Maestrano::paramWithPreset('', 'api.key');
     }
 
     public function testPresetNotConfigured()
     {
-        $this->setExpectedException(Maestrano_Config_Error::class, "Maestrano was not configured for preset 'another-marketplace'");
+        $this->setExpectedException('Maestrano_Config_Error', "Maestrano was not configured for preset 'another-marketplace'");
 
         Maestrano::with('some-marketplace')->configure($this->config['marketplaces'][0]);
         Maestrano::paramWithPreset('another-marketplace', 'api.key');

--- a/tests/Saml/XmlSecTest.php
+++ b/tests/Saml/XmlSecTest.php
@@ -2,11 +2,10 @@
 
 class Maestrano_Saml_XmlSecTest extends PHPUnit_Framework_TestCase
 {
-    private $_settings;
-    
     public function setUp()
     {
-        Maestrano::configure(array('environment' => 'production'));
+        $this->config = MaestranoTestHelper::getConfig();
+        Maestrano::with('some-marketplace')->configure($this->config['marketplaces'][0]);
         $this->settings = SamlTestHelper::getXmlSecSamlTestSettings();
     }
 

--- a/tests/Sso/GroupTest.php
+++ b/tests/Sso/GroupTest.php
@@ -9,30 +9,31 @@ class Maestrano_Sso_GroupTest extends PHPUnit_Framework_TestCase
     private $subject;
 
     /**
-    * Initializes the Test Suite
-    */
+     * Initializes the Test Suite
+     */
     public function setUp()
     {
-      Maestrano::configure(array('environment' => 'production'));
-    	$this->samlResp = new SamlMnoRespStub();
-    	$this->subject = new Maestrano_Sso_Group($this->samlResp);
+        $config = MaestranoTestHelper::getConfig();
+        $marketplace = 'some-marketplace';
+        Maestrano::with($marketplace)->configure($config['marketplaces'][0]);
+
+        $this->samlResp = new SamlMnoRespStub();
+        $this->subject = new Maestrano_Sso_Group($this->samlResp);
     }
 
+    public function testAttributeParsing()
+    {
+        $att = $this->samlResp->getAttributes();
 
-    public function testAttributeParsing() {
-  		$att = $this->samlResp->getAttributes();
-
-  		$this-> assertEquals($att["group_uid"], $this->subject->getUid());
-  		$this-> assertEquals($att["group_name"], $this->subject->getName());
-  		$this-> assertEquals($att["group_email"], $this->subject->getEmail());
-  		$this-> assertEquals(new DateTime($att["group_end_free_trial"]), $this->subject->getFreeTrialEndAt());
-  		$this-> assertEquals($att["company_name"], $this->subject->getCompanyName());
-  		$this-> assertEquals(($att["group_has_credit_card"] == "true"), $this->subject->hasCreditCard());
-
-  		$this-> assertEquals($att["group_currency"], $this->subject->getCurrency());
-  		$this-> assertEquals(new DateTimeZone($att["group_timezone"]), $this->subject->getTimezone());
-  		$this-> assertEquals($att["group_country"], $this->subject->getCountry());
-  		$this-> assertEquals($att["group_city"], $this->subject->getCity());
+        $this->assertEquals($att["group_uid"], $this->subject->getUid());
+        $this->assertEquals($att["group_name"], $this->subject->getName());
+        $this->assertEquals($att["group_email"], $this->subject->getEmail());
+        $this->assertEquals(new DateTime($att["group_end_free_trial"]), $this->subject->getFreeTrialEndAt());
+        $this->assertEquals($att["company_name"], $this->subject->getCompanyName());
+        $this->assertEquals(($att["group_has_credit_card"] == "true"), $this->subject->hasCreditCard());
+        $this->assertEquals($att["group_currency"], $this->subject->getCurrency());
+        $this->assertEquals(new DateTimeZone($att["group_timezone"]), $this->subject->getTimezone());
+        $this->assertEquals($att["group_country"], $this->subject->getCountry());
+        $this->assertEquals($att["group_city"], $this->subject->getCity());
     }
 }
-?>

--- a/tests/Sso/ServiceTest.php
+++ b/tests/Sso/ServiceTest.php
@@ -26,7 +26,6 @@ class Maestrano_Sso_ServiceTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('/maestrano/auth/saml/consume.php?marketplace=some-marketplace', $this->ssoService->getConsumePath());
         $this->assertEquals('http://php-demoapp.maestrano.dev/maestrano/auth/saml/consume.php?marketplace=some-marketplace', $this->ssoService->getConsumeUrl());
         $this->assertEquals('https://api-hub.maestrano.com/app_logout?user_uid=uid-fd45s', $this->ssoService->getLogoutUrl('uid-fd45s'));
-        $this->assertEquals('https://api-hub.maestrano.com/app_access_unauthorized', $this->ssoService->getUnauthorizedUrl());
         $this->assertEquals('https://api-hub.maestrano.com/api/v1/auth/saml', $this->ssoService->getIdpUrl());
         $this->assertEquals('https://api-hub.maestrano.com/api/v1/auth/saml/user?session=token', $this->ssoService->getSessionCheckUrl('user', 'token'));
     }

--- a/tests/Sso/ServiceTest.php
+++ b/tests/Sso/ServiceTest.php
@@ -9,69 +9,25 @@ class Maestrano_Sso_ServiceTest extends PHPUnit_Framework_TestCase
     protected $ssoService;
 
     /**
-    * Initializes the Test Suite
-    */
+     * Initializes the Test Suite
+     */
     public function setUp()
     {
-      $this->config = array(
-        'environment' => 'production',
-        'app' => array(
-          'host' => "https://mysuperapp.com",
-        ),
-        'api' => array(
-          'id' => "myappid",
-          'key' => "myappkey",
-          'group_id' => "mygroupid",
-          'host' => 'https://someapihost.com'
-        ),
-        'sso' => array(
-          'init_path' => "/mno/init_path.php",
-          'consume_path' => "/mno/consume_path.php",
-          'idp' => "https://mysuperidp.com",
-          'idm' => "https://mysuperidm.com",
-          'x509_fingerprint' => "some-x509_fingerprint",
-          'x509_certificate' => "some-x509_certificate"
-        ),
-        'connec' => array(
-          'enabled' => true,
-          'host' => 'http://connec.maestrano.io',
-          'base_path' => '/api',
-          'v2_path' => '/v2',
-          'reports_path' => '/reports'
-        ),
-        'webhook' => array(
-          'account' => array(
-            'groups_path' => "/mno/groups/:id",
-            'group_users_path' => "/mno/groups/:group_id/users/:id"
-          ),
-          'connec' => array(
-            'enabled' => true,
-            'initialization_path' => "/mno/connec/initialization",
-            'notifications_path' => "/mno/connec/notifications",
-            'subscriptions' => array(
-              'organizations' => true,
-              'people' => true
-            )
-          )
-        )
-      );
-      $preset = 'some-marketplace';
-      Maestrano::with($preset)->configure($this->config);
-      $this->ssoService = Maestrano::ssoWithPreset($preset);
-    }
+        $this->config = MaestranoTestHelper::getConfig();
+        $preset = 'some-marketplace';
+        Maestrano::with($preset)->configure($this->config['marketplaces'][0]);
 
+        $this->ssoService = Maestrano::ssoWithPreset($preset);
+    }
 
     public function testAttributeParsing() {
-  		$this-> assertEquals(true, $this->ssoService->isSsoEnabled());
-      $this-> assertEquals(true, $this->ssoService->isSloEnabled());
-      $this-> assertEquals('/mno/init_path.php', $this->ssoService->getInitPath());
-      $this-> assertEquals('https://mysuperapp.com/mno/init_path.php', $this->ssoService->getInitUrl());
-      $this-> assertEquals('/mno/consume_path.php', $this->ssoService->getConsumePath());
-      $this-> assertEquals('https://mysuperapp.com/mno/consume_path.php', $this->ssoService->getConsumeUrl());
-      $this-> assertEquals('https://mysuperidp.com/app_logout', $this->ssoService->getLogoutUrl());
-      $this-> assertEquals('https://someapihost.com/app_access_unauthorized', $this->ssoService->getUnauthorizedUrl());
-      $this-> assertEquals('https://mysuperidp.com/api/v1/auth/saml', $this->ssoService->getIdpUrl());
-      $this-> assertEquals('https://mysuperidp.com/api/v1/auth/saml/user?session=token', $this->ssoService->getSessionCheckUrl('user', 'token'));
+        $this->assertEquals('/maestrano/auth/saml/init.php?marketplace=some-marketplace', $this->ssoService->getInitPath());
+        $this->assertEquals('http://php-demoapp.maestrano.dev/maestrano/auth/saml/init.php?marketplace=some-marketplace', $this->ssoService->getInitUrl());
+        $this->assertEquals('/maestrano/auth/saml/consume.php?marketplace=some-marketplace', $this->ssoService->getConsumePath());
+        $this->assertEquals('http://php-demoapp.maestrano.dev/maestrano/auth/saml/consume.php?marketplace=some-marketplace', $this->ssoService->getConsumeUrl());
+        $this->assertEquals('https://api-hub.maestrano.com/app_logout?user_uid=uid-fd45s', $this->ssoService->getLogoutUrl('uid-fd45s'));
+        $this->assertEquals('https://api-hub.maestrano.com/app_access_unauthorized', $this->ssoService->getUnauthorizedUrl());
+        $this->assertEquals('https://api-hub.maestrano.com/api/v1/auth/saml', $this->ssoService->getIdpUrl());
+        $this->assertEquals('https://api-hub.maestrano.com/api/v1/auth/saml/user?session=token', $this->ssoService->getSessionCheckUrl('user', 'token'));
     }
 }
-?>

--- a/tests/Sso/SessionTest.php
+++ b/tests/Sso/SessionTest.php
@@ -1,275 +1,242 @@
 <?php
-  
+
 class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
 {
+    private $marketplace;
     private $httpSession;
     private $subject;
     private $httpClient;
-    
+
     /**
-    * Initializes the Test Suite
-    */
+     * Initializes the Test Suite
+     */
     public function setUp()
     {
-      Maestrano::configure(array('environment' => 'production', 'sso' => array('slo_enabled' => true)));
-      
-      $this->mnoSession = array(
-		"uid" => "usr-1",
-        "group_uid" => "cld-1",
-        "session" => "sessiontoken",
-        "session_recheck" => "2014-06-22T01:00:00Z"
-      );
-      
-      $this->httpSession = array();
-      SessionTestHelper::setMnoEntry($this->httpSession,$this->mnoSession);
+        $config = MaestranoTestHelper::getConfig();
+        $this->marketplace = 'some-marketplace';
+        Maestrano::with($this->marketplace)->configure($config['marketplaces'][0]);
 
-      $this->httpClient = new MnoHttpClientStub();
+        $this->mnoSession = array(
+            "uid" => "usr-1",
+            "group_uid" => "cld-1",
+            "session" => "sessiontoken",
+            "session_recheck" => "2017-02-28T08:10:20Z"
+        );
+
+        $this->httpSession = array();
+        SessionTestHelper::setMnoEntry($this->httpSession, $this->mnoSession);
+
+        $this->httpClient = new MnoHttpClientStub();
     }
-    
-    
-  	
-  	public function testContructsAnInstanceFromHttpSession()
-  	{
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
 
-  		$this->assertEquals($this->httpSession, $this->subject->getHttpSession());
-  		$this->assertEquals($this->mnoSession["uid"], $this->subject->getUid());
-  		$this->assertEquals($this->mnoSession["group_uid"], $this->subject->getGroupUid());
-  		$this->assertEquals($this->mnoSession["session"], $this->subject->getSessionToken());
-  		$this->assertEquals(new DateTime($this->mnoSession["session_recheck"]), $this->subject->getRecheck());
-  	}
+    public function testContructsAnInstanceFromHttpSession()
+    {
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
 
-  	
-  	public function testContructsAnInstanceFromHttpSessionAndSsoUser()
-  	{
-  		$samlResp = new SamlMnoRespStub();
-  		$user = new Maestrano_Sso_User($samlResp);
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession, $user);
+        $this->assertEquals($this->httpSession, $this->subject->getHttpSession());
+        $this->assertEquals($this->mnoSession["uid"], $this->subject->getUid());
+        $this->assertEquals($this->mnoSession["group_uid"], $this->subject->getGroupUid());
+        $this->assertEquals($this->mnoSession["session"], $this->subject->getSessionToken());
+        $this->assertEquals(new DateTime($this->mnoSession["session_recheck"]), $this->subject->getRecheck());
+    }
 
-  		$this->assertEquals($this->httpSession, $this->subject->getHttpSession());
-  		$this->assertEquals($user->getUid(), $this->subject->getUid());
-  		$this->assertEquals($user->getGroupUid(), $this->subject->getGroupUid());
-  		$this->assertEquals($user->getSsoSession(), $this->subject->getSessionToken());
-  		$this->assertEquals($user->getSsoSessionRecheck(), $this->subject->getRecheck());
-  	}
+    public function testContructsAnInstanceFromHttpSessionAndSsoUser()
+    {
+        $samlResp = new SamlMnoRespStub();
+        $user = new Maestrano_Sso_User($samlResp);
+        $this->subject = new Maestrano_Sso_Session($this->httpSession, $user);
 
-  	
-  	public function testIsRemoteCheckRequiredReturnsTrueIfRecheckIsBeforeNow()
-  	{
-  		$date = new DateTime();
-      $date->sub(new DateInterval('PT1M'));
-  		$this->mnoSession["session_recheck"] = $date->format(DateTime::ISO8601);
-  		SessionTestHelper::setMnoEntry($this->httpSession,$this->mnoSession);
-      
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
+        $this->assertEquals($this->httpSession, $this->subject->getHttpSession());
+        $this->assertEquals($user->getUid(), $this->subject->getUid());
+        $this->assertEquals($user->getGroupUid(), $this->subject->getGroupUid());
+        $this->assertEquals($user->getSsoSession(), $this->subject->getSessionToken());
+        $this->assertEquals($user->getSsoSessionRecheck(), $this->subject->getRecheck());
+    }
 
-  		// test
-  		$this->assertTrue($this->subject->isRemoteCheckRequired());
-  	}
+    public function testIsRemoteCheckRequiredReturnsTrueIfRecheckIsBeforeNow()
+    {
+        $date = new DateTime();
+        $date->sub(new DateInterval('PT1M'));
+        $this->mnoSession["session_recheck"] = $date->format(DateTime::ISO8601);
+        SessionTestHelper::setMnoEntry($this->httpSession, $this->mnoSession, $this->marketplace);
 
-  	
-  	public function testRemoteCheckRequiredReturnsFalseIfRecheckIsAfterNow()
-  	{
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT1M'));
-  		$this->mnoSession["session_recheck"] = $date->format(DateTime::ISO8601);
-  		SessionTestHelper::setMnoEntry($this->httpSession,$this->mnoSession);
-      
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
 
-  		// test
-  		$this->assertFalse($this->subject->isRemoteCheckRequired());
-  	}
+        // test
+        $this->assertTrue($this->subject->isRemoteCheckRequired());
+    }
 
-  	
-  	public function testperformRemoteCheckWhenValidReturnsTrueAndAssignRecheckIfValid()
-  	{   
-  		// Response preparation
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT1M'));
-      
-  		$resp = array();
-  		$resp["valid"] = "true";
-  		$resp["recheck"] = $date->format(DateTime::ISO8601);
-		  
-  		$this->httpClient->setResponseStub($resp);
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
+    public function testRemoteCheckRequiredReturnsFalseIfRecheckIsAfterNow()
+    {
+        $date = new DateTime();
+        $date->add(new DateInterval('PT1M'));
+        $this->mnoSession["session_recheck"] = $date->format(DateTime::ISO8601);
+        SessionTestHelper::setMnoEntry($this->httpSession, $this->mnoSession, $this->marketplace);
 
-  		// Tests
-  		$this->assertTrue($this->subject->performRemoteCheck($this->httpClient));
-  		$this->assertEquals($date->format(DateTime::ISO8601), $this->subject->getRecheck()->format(DateTime::ISO8601));
-  	}
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
 
-  	
-  	public function testPerformRemoteCheckWhenInvalidReturnsFalseAndLeaveRecheckUnchanged()
-  	{
-  		// Response preparation
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT1M'));
-  		$resp = array();
-  		$resp["valid"] = "false";
-  		$resp["recheck"] = $date->format(DateTime::ISO8601);
+        // test
+        $this->assertFalse($this->subject->isRemoteCheckRequired());
+    }
 
-  		$this->httpClient->setResponseStub($resp);
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-  		$recheck = $this->subject->getRecheck();
-		
-  		$this->assertFalse($this->subject->performRemoteCheck($this->httpClient));
-  		$this->assertEquals($recheck, $this->subject->getRecheck());
-  	}
+    public function testPerformRemoteCheckWhenValidReturnsTrueAndAssignRecheckIfValid()
+    {
+        // Response preparation
+        $date = new DateTime();
+        $date->add(new DateInterval('PT1M'));
+
+        $resp = array();
+        $resp["valid"] = "true";
+        $resp["recheck"] = $date->format(DateTime::ISO8601);
+
+        $this->httpClient->setResponseStub($resp);
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+
+        // Tests
+        $this->assertTrue($this->subject->performRemoteCheck($this->httpClient));
+        $this->assertEquals($date->format(DateTime::ISO8601), $this->subject->getRecheck()->format(DateTime::ISO8601));
+    }
+
+    public function testPerformRemoteCheckWhenInvalidReturnsFalseAndLeaveRecheckUnchanged()
+    {
+        // Response preparation
+        $date = new DateTime();
+        $date->add(new DateInterval('PT1M'));
+        $resp = array();
+        $resp["valid"] = "false";
+        $resp["recheck"] = $date->format(DateTime::ISO8601);
+
+        $this->httpClient->setResponseStub($resp);
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $recheck = $this->subject->getRecheck();
+
+        $this->assertFalse($this->subject->performRemoteCheck($this->httpClient));
+        $this->assertEquals($recheck, $this->subject->getRecheck());
+    }
+
+    public function testSaveSavesTheMaestranoSessionInHttpSession()
+    {
+
+        $oldSubject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $oldSubject->setUid($oldSubject->getUid() + "aaa");
+        $oldSubject->setGroupUid($oldSubject->getGroupUid() + "aaa");
+        $oldSubject->setSessionToken($oldSubject->getSessionToken() + "aaa");
+        $date = new DateTime();
+        $date->add(new DateInterval('PT100M'));
+        $oldSubject->setRecheck($date);
+        $oldSubject->save();
+
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+
+        $this->assertEquals($oldSubject->getUid(), $this->subject->getUid());
+        $this->assertEquals($oldSubject->getGroupUid(), $this->subject->getGroupUid());
+        $this->assertEquals($oldSubject->getSessionToken(), $this->subject->getSessionToken());
+        $this->assertEquals($oldSubject->getRecheck(), $this->subject->getRecheck());
+    }
+
+    public function testIsValidWhenIfSessionSpecifiedAndNoMaestranoSsoSessionReturnsTrue()
+    {
+        // Http context
+        $this->httpSession["some-marketplace"] = null;
+
+        // test
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->assertTrue($this->subject->isValid(true));
+    }
+
+    public function testIsValidWhenNoRecheckRequiredReturnsTrue()
+    {
+        // Make sure any remote response is negative
+        $date = new DateTime();
+        $date->add(new DateInterval('PT100M'));
+        $resp = array();
+        $resp["valid"] = "false";
+        $resp["recheck"] = $date->format(DateTime::ISO8601);
+        $this->httpClient->setResponseStub($resp);
+
+        // Set local recheck in the future
+        $localRecheck = new DateTime();
+        $localRecheck->add(new DateInterval('PT1M'));
+
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject->setRecheck($localRecheck);
+
+        // test
+        $this->assertTrue($this->subject->isValid(false, $this->httpClient));
+    }
 
 
-  	
-  	public function testSaveSavesTheMaestranoSessionInHttpSession()
-  	{
-  		
-  		$oldSubject = new Maestrano_Sso_Session($this->httpSession);
-  		$oldSubject->setUid($oldSubject->getUid() + "aaa");
-  		$oldSubject->setGroupUid($oldSubject->getGroupUid() + "aaa");
-  		$oldSubject->setSessionToken($oldSubject->getSessionToken() + "aaa");
-      
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT100M'));
-  		$oldSubject->setRecheck($date);
-  		$oldSubject->save();
-		
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-  		$this->assertEquals($oldSubject->getUid(), $this->subject->getUid());
-  		$this->assertEquals($oldSubject->getGroupUid(), $this->subject->getGroupUid());
-  		$this->assertEquals($oldSubject->getSessionToken(), $this->subject->getSessionToken());
-  		$this->assertEquals($oldSubject->getRecheck(), $this->subject->getRecheck());
-  	}
+    public function testIsValidWhenRecheckRequiredAndValidReturnsTrueAndSaveTheSession()
+    {
+        // Make sure any remote response is negative
+        $date = new DateTime();
+        $date->add(new DateInterval('PT100M'));
+        $resp = array();
+        $resp["valid"] = "true";
+        $resp["recheck"] = $date->format(DateTime::ISO8601);
+        $this->httpClient->setResponseStub($resp);
 
-  	
-  	public function testisValidWhenSloDisabled_ItShouldReturnTrue()
-  	{
-  		// Disable SLO
-  		Maestrano::configure(array('environment' => 'production', 'sso' => array('slo_enabled' => false)));
-		
-  		// Response preparation (session not valid)
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT1M'));
-  		$resp = array();
-  		$resp["valid"] = "false";
-  		$resp["recheck"] = $date->format(DateTime::ISO8601);
-  		$this->httpClient->setResponseStub($resp);
-		
-  		// Set local recheck to force remote recheck
-  		$localRecheck = new DateTime();
-      $localRecheck->sub(new DateInterval('PT1M'));
-      
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-  		$this->subject->setRecheck($localRecheck);
-		
-  		$this->assertTrue($this->subject->isValid(false,$this->httpClient));
-  	}
+        // Set local recheck in the past
+        $localRecheck = new DateTime();
+        $localRecheck->sub(new DateInterval('PT1M'));
+        $oldSubject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $oldSubject->setRecheck($localRecheck);
 
-  	
-  	public function testIsValidWhenIfSessionSpecifiedAndNoMaestranoSsoSessionReturnsTrue()
-  	{
-  		// Http context
-  		$this->httpSession["maestrano"] = null;
+        // test 1 - validity
+        $this->assertTrue($oldSubject->isValid(false, $this->httpClient));
 
-  		// test
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-  		$this->assertTrue($this->subject->isValid(true));
-  	}
+        // Create a new subject to test session persistence
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
 
-  	
-  	public function testIsValidWhenNoRecheckRequiredReturnsTrue()
-  	{	
-  		// Make sure any remote response is negative
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT100M'));
-  		$resp = array();
-  		$resp["valid"] = "false";
-  		$resp["recheck"] = $date->format(DateTime::ISO8601);
-  		$this->httpClient->setResponseStub($resp);
-		
-  		// Set local recheck in the future
-  		$localRecheck = new DateTime();
-      $localRecheck->add(new DateInterval('PT1M'));
-      
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-  		$this->subject->setRecheck($localRecheck);
+        // test 2 - session persistence
+        $this->assertEquals($date->format(DateTime::ISO8601), $this->subject->getRecheck()->format(DateTime::ISO8601));
+    }
 
-  		// test
-  		$this->assertTrue($this->subject->isValid(false,$this->httpClient));
-  	}
 
-  	
-  	public function testIsValidWhenRecheckRequiredAndValidReturnsTrueAndSaveTheSession()
-  	{
-  		// Make sure any remote response is negative
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT100M'));
-  		$resp = array();
-  		$resp["valid"] = "true";
-  		$resp["recheck"] = $date->format(DateTime::ISO8601);
-  		$this->httpClient->setResponseStub($resp);
+    public function isValid_WhenRecheckRequiredAndInvalid_ItShouldReturnFalse()
+    {
+        // Make sure any remote response is negative
+        $date = new DateTime();
+        $date->add(new DateInterval('PT100M'));
+        $resp = array();
+        $resp["valid"] = "false";
+        $resp["recheck"] = $date->format(DateTime::ISO8601);
+        $this->httpClient->setResponseStub($resp);
 
-  		// Set local recheck in the past
-  		$localRecheck = new DateTime();
-      $localRecheck->sub(new DateInterval('PT1M'));
-  		$oldSubject = new Maestrano_Sso_Session($this->httpSession);
-  		$oldSubject->setRecheck($localRecheck);
-		
-  		// test 1 - validity
-  		$this->assertTrue($oldSubject->isValid(false,$this->httpClient));
-		
-  		// Create a new subject to test session persistence
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-		
-  		// test 2 - session persistence
-  		$this->assertEquals($date->format(DateTime::ISO8601), $this->subject->getRecheck()->format(DateTime::ISO8601));
-  	}
+        // Set local recheck in the past
+        $localRecheck = new DateTime();
+        $localRecheck->sub(new DateInterval('PT1M'));
 
-  	
-  	public function isValid_WhenRecheckRequiredAndInvalid_ItShouldReturnFalse()
-  	{
-  		// Make sure any remote response is negative
-  		$date = new DateTime();
-      $date->add(new DateInterval('PT100M'));
-  		$resp = array();
-  		$resp["valid"] = "false";
-  		$resp["recheck"] = $date->format(DateTime::ISO8601);
-  		$this->httpClient->setResponseStub($resp);
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject->setRecheck($localRecheck);
 
-  		// Set local recheck in the past
-  		$localRecheck = new DateTime();
-      $localRecheck->sub(new DateInterval('PT1M'));
-      
-  		$this->subject = new Maestrano_Sso_Session($this->httpSession);
-  		$this->subject->setRecheck($localRecheck);
+        // test 1 - validity
+        $this->assertFalse($this->subject->isValid(false, $this->httpClient));
+    }
 
-  		// test 1 - validity
-  		$this->assertFalse($this->subject->isValid(false,$this->httpClient));
-  	}
+    public function ssoTokenExists_IfSsoTokenExists_ItShouldReturnTrue()
+    {
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
 
-	public function ssoTokenExists_IfSsoTokenExists_ItShouldReturnTrue()
-	{
-		$this->subject = new Maestrano_Sso_Session($this->httpSession);
+        // test 1 - validity
+        $this->assertTrue($this->subject->ssoTokenExists());
+    }
 
-		// test 1 - validity
-		$this->assertTrue($this->subject->ssoTokenExists());
-	}
+    public function ssoTokenExists_IfNoSsoTokenExists_ItShouldReturnFalse()
+    {
+        $emptySession = array();
+        $this->subject = new Maestrano_Sso_Session($emptySession);
 
-	public function ssoTokenExists_IfNoSsoTokenExists_ItShouldReturnFalse()
-	{
-		$emptySession = array();
-		$this->subject = new Maestrano_Sso_Session($emptySession);
+        // test 1 - validity
+        $this->assertFalse($this->subject->ssoTokenExists());
+    }
 
-		// test 1 - validity
-		$this->assertFalse($this->subject->ssoTokenExists());
-	}
+    public function isValid_WhenNoSsoTokenIsPresent_ItShouldReturnFalse()
+    {
+        $emptySession = array();
+        $this->subject = new Maestrano_Sso_Session($emptySession);
 
-	public function isValid_WhenNoSsoTokenIsPresent_ItShouldReturnFalse()
-	{
-		$emptySession = array();
-		$this->subject = new Maestrano_Sso_Session($emptySession);
-
-		// test 1 - validity
-		$this->assertFalse($this->subject->isValid());
-	}
+        // test 1 - validity
+        $this->assertFalse($this->subject->isValid());
+    }
 }
-?>

--- a/tests/Sso/SessionTest.php
+++ b/tests/Sso/SessionTest.php
@@ -44,7 +44,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
     {
         $samlResp = new SamlMnoRespStub();
         $user = new Maestrano_Sso_User($samlResp);
-        $this->subject = new Maestrano_Sso_Session($this->httpSession, $user);
+        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession, $user);
 
         $this->assertEquals($this->httpSession, $this->subject->getHttpSession());
         $this->assertEquals($user->getUid(), $this->subject->getUid());

--- a/tests/Sso/SessionTest.php
+++ b/tests/Sso/SessionTest.php
@@ -31,7 +31,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
 
     public function testContructsAnInstanceFromHttpSession()
     {
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         $this->assertEquals($this->httpSession, $this->subject->getHttpSession());
         $this->assertEquals($this->mnoSession["uid"], $this->subject->getUid());
@@ -44,7 +44,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
     {
         $samlResp = new SamlMnoRespStub();
         $user = new Maestrano_Sso_User($samlResp);
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession, $user);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession, $user);
 
         $this->assertEquals($this->httpSession, $this->subject->getHttpSession());
         $this->assertEquals($user->getUid(), $this->subject->getUid());
@@ -60,7 +60,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $this->mnoSession["session_recheck"] = $date->format(DateTime::ISO8601);
         SessionTestHelper::setMnoEntry($this->httpSession, $this->mnoSession, $this->marketplace);
 
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         // test
         $this->assertTrue($this->subject->isRemoteCheckRequired());
@@ -73,7 +73,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $this->mnoSession["session_recheck"] = $date->format(DateTime::ISO8601);
         SessionTestHelper::setMnoEntry($this->httpSession, $this->mnoSession, $this->marketplace);
 
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         // test
         $this->assertFalse($this->subject->isRemoteCheckRequired());
@@ -90,7 +90,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $resp["recheck"] = $date->format(DateTime::ISO8601);
 
         $this->httpClient->setResponseStub($resp);
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         // Tests
         $this->assertTrue($this->subject->performRemoteCheck($this->httpClient));
@@ -107,7 +107,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $resp["recheck"] = $date->format(DateTime::ISO8601);
 
         $this->httpClient->setResponseStub($resp);
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
         $recheck = $this->subject->getRecheck();
 
         $this->assertFalse($this->subject->performRemoteCheck($this->httpClient));
@@ -117,7 +117,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
     public function testSaveSavesTheMaestranoSessionInHttpSession()
     {
 
-        $oldSubject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $oldSubject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
         $oldSubject->setUid($oldSubject->getUid() + "aaa");
         $oldSubject->setGroupUid($oldSubject->getGroupUid() + "aaa");
         $oldSubject->setSessionToken($oldSubject->getSessionToken() + "aaa");
@@ -126,7 +126,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $oldSubject->setRecheck($date);
         $oldSubject->save();
 
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         $this->assertEquals($oldSubject->getUid(), $this->subject->getUid());
         $this->assertEquals($oldSubject->getGroupUid(), $this->subject->getGroupUid());
@@ -140,7 +140,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $this->httpSession["some-marketplace"] = null;
 
         // test
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
         $this->assertTrue($this->subject->isValid(true));
     }
 
@@ -158,7 +158,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $localRecheck = new DateTime();
         $localRecheck->add(new DateInterval('PT1M'));
 
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
         $this->subject->setRecheck($localRecheck);
 
         // test
@@ -179,14 +179,14 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         // Set local recheck in the past
         $localRecheck = new DateTime();
         $localRecheck->sub(new DateInterval('PT1M'));
-        $oldSubject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $oldSubject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
         $oldSubject->setRecheck($localRecheck);
 
         // test 1 - validity
         $this->assertTrue($oldSubject->isValid(false, $this->httpClient));
 
         // Create a new subject to test session persistence
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         // test 2 - session persistence
         $this->assertEquals($date->format(DateTime::ISO8601), $this->subject->getRecheck()->format(DateTime::ISO8601));
@@ -207,7 +207,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
         $localRecheck = new DateTime();
         $localRecheck->sub(new DateInterval('PT1M'));
 
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
         $this->subject->setRecheck($localRecheck);
 
         // test 1 - validity
@@ -216,7 +216,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
 
     public function ssoTokenExists_IfSsoTokenExists_ItShouldReturnTrue()
     {
-        $this->subject = Maestrano_Sso_Session::create($this->marketplace, $this->httpSession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $this->httpSession);
 
         // test 1 - validity
         $this->assertTrue($this->subject->ssoTokenExists());
@@ -225,7 +225,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
     public function ssoTokenExists_IfNoSsoTokenExists_ItShouldReturnFalse()
     {
         $emptySession = array();
-        $this->subject = new Maestrano_Sso_Session($emptySession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $emptySession);
 
         // test 1 - validity
         $this->assertFalse($this->subject->ssoTokenExists());
@@ -234,7 +234,7 @@ class Maestrano_Sso_SessionTest extends PHPUnit_Framework_TestCase
     public function isValid_WhenNoSsoTokenIsPresent_ItShouldReturnFalse()
     {
         $emptySession = array();
-        $this->subject = new Maestrano_Sso_Session($emptySession);
+        $this->subject = new Maestrano_Sso_Session($this->marketplace, $emptySession);
 
         // test 1 - validity
         $this->assertFalse($this->subject->isValid());

--- a/tests/Sso/UserTest.php
+++ b/tests/Sso/UserTest.php
@@ -1,5 +1,5 @@
 <?php
-  
+
 /**
  * Unit tests for AuthN Request
  */
@@ -7,61 +7,35 @@ class Maestrano_Sso_UserTest extends PHPUnit_Framework_TestCase
 {
     private $samlResp;
     private $subject;
-    
+
     /**
-    * Initializes the Test Suite
-    */
+     * Initializes the Test Suite
+     */
     public function setUp()
     {
-      Maestrano::configure(array('environment' => 'production'));
-    	$this->samlResp = new SamlMnoRespStub();
-    	$this->subject = new Maestrano_Sso_User($this->samlResp);
+        $config = MaestranoTestHelper::getConfig();
+        $marketplace = 'some-marketplace';
+        Maestrano::with($marketplace)->configure($config['marketplaces'][0]);
+
+        $this->samlResp = new SamlMnoRespStub();
+        $this->subject = new Maestrano_Sso_User($this->samlResp);
     }
-    
-    
-    public function testAttributeParsing() {
-  		$att = $this->samlResp->getAttributes();
 
-  		$this->assertEquals($att["mno_session"], $this->subject->getSsoSession());
-  		$this->assertEquals(new DateTime($att["mno_session_recheck"]), $this->subject->getSsoSessionRecheck());
-  		$this->assertEquals($att["group_uid"], $this->subject->getGroupUid());
-  		$this->assertEquals($att["group_role"], $this->subject->getGroupRole());
-  		$this->assertEquals($att["uid"], $this->subject->getUid());
-  		$this->assertEquals($att["virtual_uid"], $this->subject->getVirtualUid());
-  		$this->assertEquals($att["email"], $this->subject->getEmail());
-  		$this->assertEquals($att["virtual_email"], $this->subject->getVirtualEmail());
-  		$this->assertEquals($att["name"], $this->subject->getFirstName());
-  		$this->assertEquals($att["surname"], $this->subject->getLastName());
-  		$this->assertEquals($att["country"], $this->subject->getCountry());
-  		$this->assertEquals($att["company_name"], $this->subject->getCompanyName());
+    public function testAttributeParsing()
+    {
+        $att = $this->samlResp->getAttributes();
+
+        $this->assertEquals($att["mno_session"], $this->subject->getSsoSession());
+        $this->assertEquals(new DateTime($att["mno_session_recheck"]), $this->subject->getSsoSessionRecheck());
+        $this->assertEquals($att["group_uid"], $this->subject->getGroupUid());
+        $this->assertEquals($att["group_role"], $this->subject->getGroupRole());
+        $this->assertEquals($att["uid"], $this->subject->getUid());
+        $this->assertEquals($att["virtual_uid"], $this->subject->getVirtualUid());
+        $this->assertEquals($att["email"], $this->subject->getEmail());
+        $this->assertEquals($att["virtual_email"], $this->subject->getVirtualEmail());
+        $this->assertEquals($att["name"], $this->subject->getFirstName());
+        $this->assertEquals($att["surname"], $this->subject->getLastName());
+        $this->assertEquals($att["country"], $this->subject->getCountry());
+        $this->assertEquals($att["company_name"], $this->subject->getCompanyName());
     }
-    
-  	public function testToIdWhenReal()
-  	{
-  		Maestrano::configure(array('environment' => 'production', 'sso' => array('creation_mode' => 'real')));
-
-  		$this->assertEquals($this->subject->getUid(),$this->subject->toId());
-  	}
-    
-  	public function testToIdWhenVirtual()
-  	{
-  		Maestrano::configure(array('environment' => 'production', 'sso' => array('creation_mode' => 'virtual')));
-		
-  		$this->assertEquals($this->subject->getVirtualUid(),$this->subject->toId());
-  	}
-    
-  	public function testToEmailWhenReal()
-  	{
-  		Maestrano::configure(array('environment' => 'production', 'sso' => array('creation_mode' => 'real')));
-
-  		$this->assertEquals($this->subject->getEmail(),$this->subject->toEmail());
-  	}
-    
-  	public function testToEmailWhenVirtual()
-  	{
-  		Maestrano::configure(array('environment' => 'production', 'sso' => array('creation_mode' => 'virtual')));
-
-  		$this->assertEquals($this->subject->getVirtualEmail(),$this->subject->toEmail());
-  	}
 }
-?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,6 +3,7 @@
 if (!defined('TEST_ROOT')) define('TEST_ROOT', dirname(__FILE__));
 
 require_once TEST_ROOT . '/../vendor/autoload.php';
+require_once TEST_ROOT . '/support/MaestranoTestHelper.php';
 require_once TEST_ROOT . '/support/sso/SessionTestHelper.php';
 require_once TEST_ROOT . '/support/saml/SamlTestHelper.php';
 require_once TEST_ROOT . '/support/stubs/SamlMnoRespStub.php';

--- a/tests/support/MaestranoTestHelper.php
+++ b/tests/support/MaestranoTestHelper.php
@@ -1,0 +1,64 @@
+<?php
+
+class MaestranoTestHelper
+{
+    public static function getConfig()
+    {
+        $config = array (
+            'marketplaces' =>
+                array (
+                    0 =>
+                        array (
+                            'nid' => 'demo-app-php-local',
+                            'marketplace' => 'some-marketplace',
+                            'environment' => 'demo-app-php',
+                            'app' =>
+                                array (
+                                    'host' => 'http://php-demoapp.maestrano.dev',
+                                    'synchronization_start_path' => '/maestrano/synchronizations',
+                                    'synchronization_toggle_path' => '/maestrano/synchronizations/toggle_sync',
+                                    'synchronization_status_path' => '/maestrano/synchronizations/:cld-uid',
+                                ),
+                            'api' =>
+                                array (
+                                    'id' => 'app-15pm',
+                                    'key' => 'e03671e37802581b6404f6db79b81d90a32187076d9b01a51b6a4a51268e8b1e',
+                                    'host' => 'https://api-hub.maestrano.com',
+                                    'base' => '/api/v1/',
+                                ),
+                            'sso' =>
+                                array (
+                                    'idm' => 'http://php-demoapp.maestrano.dev',
+                                    'init_path' => '/maestrano/auth/saml/init.php?marketplace=some-marketplace',
+                                    'consume_path' => '/maestrano/auth/saml/consume.php?marketplace=some-marketplace',
+                                    'idp' => 'https://api-hub.maestrano.com',
+                                    'x509_fingerprint' => '2f:57:71:e4:40:45:57:37:a6:84:f0:c5:82:52:2f:2e:41:b7:9d:7e',
+                                    'x509_certificate' => '-----BEGIN CERTIFICATE-----MIIDezCCQ....Q32v8p5lA==-----END CERTIFICATE-----',
+                                ),
+                            'connec' =>
+                                array (
+                                    'host' => 'https://api-connec.maestrano.com',
+                                    'base_path' => '/api/v2',
+                                    'timeout' => 300,
+                                ),
+                            'webhooks' =>
+                                array (
+                                    'account' =>
+                                        array (
+                                            'group_path' => 'test',
+                                            'group_user_path' => '',
+                                        ),
+                                    'connec' =>
+                                        array (
+                                            'external_ids' => true,
+                                            'initialization_path' => NULL,
+                                            'notification_path' => '',
+                                        )
+                                )
+                        )
+                )
+        );
+
+        return $config;
+    }
+}

--- a/tests/support/saml/SamlTestHelper.php
+++ b/tests/support/saml/SamlTestHelper.php
@@ -1,29 +1,29 @@
 <?php
-  
-class SamlTestHelper {
-  
-  public static function getXmlSecSamlTestSettings($suffix='') {
-    $settings = new Maestrano_Saml_Settings;
-    $settings->spIssuer = "http://stuff.com/endpoints/metadata.php" . $suffix;
-    $settings->spReturnUrl = "http://stuff.com/endpoints/endpoints/acs.php" . $suffix;
-    $settings->idpSingleSignOnUrl = 'http://idp.example.com/SSOService.php' . $suffix;
-    $settings->idpSingleLogOutUrl = 'http://idp.example.com/SingleLogoutService.php' . $suffix;
-    $settings->idpPublicCertificate = "-----BEGIN CERTIFICATE-----\nMIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMC\nTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYD\nVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG\n9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4\nMTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xi\nZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2Zl\naWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5v\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LO\nNoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHIS\nKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d\n1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8\nBUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7n\nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2Qar\nQ4/67OZfHd7R+POBXhophSMv1ZOo\n-----END CERTIFICATE-----\n" . $suffix;
-    
-    return $settings;
-  }
-  
-  public static function getResponse($name) {
-    return file_get_contents(TEST_ROOT . '/support/saml/responses/' . $name);
-  }
-  
-  public static function buildSamlResponse($name,$settings) {
-    $assertion = self::getResponse($name);
-    $response = new Maestrano_Saml_Response($assertion,$settings);
-    
-    return $response;
-  }
+
+class SamlTestHelper
+{
+    public static function getXmlSecSamlTestSettings($suffix = '')
+    {
+        $settings = new Maestrano_Saml_Settings;
+        $settings->spIssuer = "http://stuff.com/endpoints/metadata.php" . $suffix;
+        $settings->spReturnUrl = "http://stuff.com/endpoints/endpoints/acs.php" . $suffix;
+        $settings->idpSingleSignOnUrl = 'http://idp.example.com/SSOService.php' . $suffix;
+        $settings->idpSingleLogOutUrl = 'http://idp.example.com/SingleLogoutService.php' . $suffix;
+        $settings->idpPublicCertificate = "-----BEGIN CERTIFICATE-----\nMIICgTCCAeoCCQCbOlrWDdX7FTANBgkqhkiG9w0BAQUFADCBhDELMAkGA1UEBhMC\nTk8xGDAWBgNVBAgTD0FuZHJlYXMgU29sYmVyZzEMMAoGA1UEBxMDRm9vMRAwDgYD\nVQQKEwdVTklORVRUMRgwFgYDVQQDEw9mZWlkZS5lcmxhbmcubm8xITAfBgkqhkiG\n9w0BCQEWEmFuZHJlYXNAdW5pbmV0dC5ubzAeFw0wNzA2MTUxMjAxMzVaFw0wNzA4\nMTQxMjAxMzVaMIGEMQswCQYDVQQGEwJOTzEYMBYGA1UECBMPQW5kcmVhcyBTb2xi\nZXJnMQwwCgYDVQQHEwNGb28xEDAOBgNVBAoTB1VOSU5FVFQxGDAWBgNVBAMTD2Zl\naWRlLmVybGFuZy5ubzEhMB8GCSqGSIb3DQEJARYSYW5kcmVhc0B1bmluZXR0Lm5v\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDivbhR7P516x/S3BqKxupQe0LO\nNoliupiBOesCO3SHbDrl3+q9IbfnfmE04rNuMcPsIxB161TdDpIesLCn7c8aPHIS\nKOtPlAeTZSnb8QAu7aRjZq3+PbrP5uW3TcfCGPtKTytHOge/OlJbo078dVhXQ14d\n1EDwXJW1rRXuUt4C8QIDAQABMA0GCSqGSIb3DQEBBQUAA4GBACDVfp86HObqY+e8\nBUoWQ9+VMQx1ASDohBjwOsg2WykUqRXF+dLfcUH9dWR63CtZIKFDbStNomPnQz7n\nbK+onygwBspVEbnHuUihZq3ZUdmumQqCw4Uvs/1Uvq3orOo/WJVhTyvLgFVK2Qar\nQ4/67OZfHd7R+POBXhophSMv1ZOo\n-----END CERTIFICATE-----\n" . $suffix;
+
+        return $settings;
+    }
+
+    public static function getResponse($name)
+    {
+        return file_get_contents(TEST_ROOT . '/support/saml/responses/' . $name);
+    }
+
+    public static function buildSamlResponse($name, $settings)
+    {
+        $assertion = self::getResponse($name);
+        $response = new Maestrano_Saml_Response($assertion, $settings);
+
+        return $response;
+    }
 }
-  
-  
-?>

--- a/tests/support/sso/SessionTestHelper.php
+++ b/tests/support/sso/SessionTestHelper.php
@@ -1,11 +1,9 @@
 <?php
-  
-class SessionTestHelper {
-  
-  public static function setMnoEntry(& $httpSession, $array) {
-    $httpSession['maestrano'] = base64_encode(json_encode($array));
-  }
-  
+
+class SessionTestHelper
+{
+    public static function setMnoEntry(& $httpSession, $array)
+    {
+        $httpSession['maestrano'] = base64_encode(json_encode($array));
+    }
 }
-  
-?>

--- a/tests/support/stubs/MnoHttpClientStub.php
+++ b/tests/support/stubs/MnoHttpClientStub.php
@@ -1,59 +1,62 @@
 <?php
-  
+
 class MnoHttpClientStub extends Maestrano_Net_HttpClient
 {
-  private $responseStubs;
-  private $defaultResponseStub;
-  
-  public function __construct()
-  {
-    $this->responseStubs = array();
-  }
-  
-	public function get($url) {
-		return $this->getResponseStub($url,null,null);
-	}
-  
-	public function getResponseStub($url, $params = null, $payload = null) {
-    $keyStr = $url;
-    $paramsStr = null;
-    if ($params != null) {
-      $paramsStr = json_encode($params);
+    private $responseStubs;
+    private $defaultResponseStub;
+
+    public function __construct()
+    {
+        $this->responseStubs = array();
     }
-		
-		if ($paramsStr != null) {
-			$keyStr += "?" + $paramsStr;
-		}
-		
-		if ($payload != null) {
-			$keyStr += "@@payload@@" + $payload;
-		}
-		
-    return (isset($this->responseStubs[$keyStr]) ? $this->responseStubs[$keyStr] : $this->defaultResponseStub);
-	}
-  
-	public function setResponseStub($responseStub,$url = null, $params = null, $payload = null) {
-		if ($url == null) {
-		  $this->defaultResponseStub = json_encode($responseStub);
-      return true;
-		}
-    
-    $keyStr = $url;
-    $paramsStr = null;
-    if ($params != null) {
-      $paramsStr = json_encode($params);
+
+    public function get($url)
+    {
+        return $this->getResponseStub($url, null, null);
     }
-		
-		if ($paramsStr != null) {
-			$keyStr += "?" + $paramsStr;
-		}
-		
-		if ($payload != null) {
-			$keyStr += "@@payload@@" + $payload;
-		}
-		
-		$this->responseStubs[$keyStr] = json_encode($responseStub);
-	}
+
+    public function getResponseStub($url, $params = null, $payload = null)
+    {
+        $keyStr = $url;
+        $paramsStr = null;
+        if ($params != null) {
+            $paramsStr = json_encode($params);
+        }
+
+        if ($paramsStr != null) {
+            $keyStr += "?" + $paramsStr;
+        }
+
+        if ($payload != null) {
+            $keyStr += "@@payload@@" + $payload;
+        }
+
+        return (isset($this->responseStubs[$keyStr]) ? $this->responseStubs[$keyStr] : $this->defaultResponseStub);
+    }
+
+    public function setResponseStub($responseStub, $url = null, $params = null, $payload = null)
+    {
+        if ($url == null) {
+            $this->defaultResponseStub = json_encode($responseStub);
+            return true;
+        }
+
+        $keyStr = $url;
+        $paramsStr = null;
+        if ($params != null) {
+            $paramsStr = json_encode($params);
+        }
+
+        if ($paramsStr != null) {
+            $keyStr += "?" + $paramsStr;
+        }
+
+        if ($payload != null) {
+            $keyStr += "@@payload@@" + $payload;
+        }
+
+        $this->responseStubs[$keyStr] = json_encode($responseStub);
+    }
 }
-  
+
 ?>


### PR DESCRIPTION
- Removed deprecated default configuration (configuration is now only coming from the developer platform)
- Removed "verify_ssl_certs"
- Removed "sso.sloenabled"
- Removed "soo.ssoenabled"
- Renamed `getLogoutWithUserUid(userUid)` to `getLogout(userUid)` (overriding deprecated `getLogout()`)
- User can now decide to use or not the virtual mode by using `$user->getUid()` & `$user->getEmail()` or `$user->getVirtualUid()` & `$user->getVirtualEmail()`
- Refactored `toMetadata` to display the configuration of a marketplace
- Remove useless var MNO_DEVPL_ENV_NAME

@BrunoChauvet Please review
@x4d3 FYI

I will merge this PR, but feel free to comment it, I will then create a new version with the changes.